### PR TITLE
Fix web image build: install workspace deps in builder stage

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -21,6 +21,7 @@ ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_DEFAULT_CURRENCY_CODE=$VITE_DEFAULT_CURRENCY_CODE
 COPY --from=installer /app/node_modules ./node_modules
 COPY --from=pruner /app/out/full/ ./
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 RUN bun --filter @spliit/web build
 
 FROM nginx:1.27-alpine


### PR DESCRIPTION
## Summary

`Dockerfile.web` fails at `RUN bun --filter @spliit/web build` with
`vite: command not found`: the builder stage copies only the root
`node_modules` from the installer stage, but bun links workspace binaries
into the nested `apps/web/node_modules/.bin`, which never makes it into
the stage.

Closes #27

## Changes

One line in `Dockerfile.web`: re-run the (cached) `bun install` after the
`out/full` copy in the builder stage, which restores the workspace layout
so `vite` is on the PATH again.

## Verification

- [x] `bun check-types`
- [x] `bun check-formatting`
- [x] `bun run test`
- [ ] I added or updated tests where appropriate — no tests applicable, the
      change only affects the Docker image build

Additionally:

- `podman build -f Dockerfile.web --build-arg APP_SCOPE=@spliit/web --build-arg VITE_API_URL=https://<my-domain> .` builds successfully
- The resulting nginx image serves the SPA; running it self-hosted behind Traefik with the API on a separate origin, sign-in and groups work

## AI-assisted development disclosure

- [ ] No AI assistance was used.
- [x] AI was used, and I included the initial prompt plus all materially
      relevant follow-up prompts below (with notes on important changes or
      decisions).
- [ ] AI was used for a new feature or larger change, and this PR includes a
      well-defined, up-to-date OpenSpec instead of prompt history.

## Prompt history or OpenSpec link

Material prompts, paraphrased (session was in German, private hostnames redacted):

1. "Host https://github.com/antonio-ivanovski/spliit-cloud on my homelab
   (rootful Podman, Traefik, split web/API domains) following my existing
   conventions" — during this, the web image build failed.
2. The diagnosis (nested workspace bin lost between build stages) and the
   one-line fix were proposed by the agent, not prompted; I had it verify by
   rebuilding and running the stack end-to-end before accepting it unchanged.
3. "Follow this repo's contributing rules" — which produced this disclosure
   and the check runs above.

## Checklist

- [x] The implementation is complete and I have reviewed all AI-generated code.
- [x] Documentation is updated when needed. — no docs affected
- [ ] Schema changes include the schema, migration, and generated client. — N/A, no schema changes
- [x] This PR contains one logical change.
- [x] Related issue: `Closes #27`
