### PR TITLE
Bug#62 Fix datepicker and typing capabilities on expense-form

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -472,3 +472,35 @@
 .landing-header strong {
   @apply font-bold text-transparent;
 }
+
+/* Native type="date" — explicit calendar SVG (browser icon invisible on dark bg). */
+input[type='date'] {
+  color-scheme: light;
+  padding-inline-end: 2rem;
+}
+
+.dark input[type='date'] {
+  color-scheme: dark;
+}
+
+input[type='date']::-webkit-calendar-picker-indicator {
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  opacity: 1;
+  background: center / contain no-repeat
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2371717a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 2v4'/%3E%3Cpath d='M16 2v4'/%3E%3Crect width='18' height='18' x='3' y='4' rx='2'/%3E%3Cpath d='M3 10h18'/%3E%3C/svg%3E");
+}
+
+.dark input[type='date']::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23d4d4d8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 2v4'/%3E%3Cpath d='M16 2v4'/%3E%3Crect width='18' height='18' x='3' y='4' rx='2'/%3E%3Cpath d='M3 10h18'/%3E%3C/svg%3E");
+}
+
+input[type='date']::-moz-calendar-picker-indicator {
+  cursor: pointer;
+  opacity: 0.85;
+}

--- a/apps/web/src/app/groups/[groupId]/expenses/expense-form/basic-details-card.tsx
+++ b/apps/web/src/app/groups/[groupId]/expenses/expense-form/basic-details-card.tsx
@@ -3,7 +3,9 @@ import {
   useEffect,
   useRef,
   useState,
+  type ComponentProps,
   type Dispatch,
+  type Ref,
   type SetStateAction,
 } from 'react'
 import { useFormState, useWatch, type UseFormReturn } from 'react-hook-form'
@@ -66,7 +68,7 @@ import { AmountInput } from './amount-input'
 import {
   enforceCurrencyPattern,
   amountPlaceholder,
-  formatDate,
+  isValidExpenseDate,
   parseCurrencyPaste,
 } from './currency-utils'
 import { applySplitToAll } from './default-item-split'
@@ -75,6 +77,10 @@ import {
   getNeutralDefaultSplit,
   savedDefaultToFormValues,
 } from './default-values'
+import {
+  formatDateInputValue,
+  parseDateInputValue,
+} from './recurrence-schedule'
 import { RecurrenceSection } from './recurrence-section'
 
 type Group = NonNullable<AppRouterOutput['groups']['get']['group']>
@@ -404,14 +410,13 @@ export function BasicDetailsCard(props: {
                 <FormItem>
                   <FormLabel>{t(`${sExpense}.DateField.label`)}</FormLabel>
                   <FormControl>
-                    <Input
-                      className="date-base"
-                      type="date"
-                      defaultValue={formatDate(field.value)}
+                    <ExpenseDateField
+                      ref={field.ref}
+                      name={field.name}
+                      value={field.value}
                       disabled={readOnly}
-                      onChange={(event) => {
-                        return field.onChange(new Date(event.target.value))
-                      }}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
                     />
                   </FormControl>
                   <FormDescription className="hidden sm:block">
@@ -746,5 +751,63 @@ export function BasicDetailsCard(props: {
         </ResponsiveDialogContent>
       </ResponsiveDialog>
     </Card>
+  )
+}
+
+function ExpenseDateField({
+  ref,
+  value,
+  onChange,
+  onBlur,
+  disabled,
+  ...props
+}: {
+  ref?: Ref<HTMLInputElement>
+  value?: Date
+  onChange: (date: Date) => void
+  disabled?: boolean
+} & Omit<ComponentProps<typeof Input>, 'type' | 'value' | 'onChange'>) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const isFocusedRef = useRef(false)
+  const valueIso = isValidExpenseDate(value) ? formatDateInputValue(value) : ''
+
+  useEffect(() => {
+    const input = inputRef.current
+    if (!input || isFocusedRef.current) return
+    if (input.value !== valueIso) input.value = valueIso
+  }, [valueIso])
+
+  const setInputRef = (node: HTMLInputElement | null) => {
+    inputRef.current = node
+    if (typeof ref === 'function') ref(node)
+    else if (ref) ref.current = node
+  }
+
+  return (
+    <Input
+      {...props}
+      ref={setInputRef}
+      className="date-base w-full"
+      type="date"
+      defaultValue={valueIso}
+      disabled={disabled}
+      onFocus={(event) => {
+        isFocusedRef.current = true
+        props.onFocus?.(event)
+      }}
+      onChange={(event) => {
+        const raw = event.target.value
+        if (!raw) return
+        const selected = parseDateInputValue(raw)
+        if (!Number.isFinite(selected.getTime())) return
+        onChange(selected)
+      }}
+      onBlur={(event) => {
+        isFocusedRef.current = false
+        onBlur?.(event)
+        const input = inputRef.current
+        if (input && !input.value && valueIso) input.value = valueIso
+      }}
+    />
   )
 }

--- a/apps/web/src/app/groups/[groupId]/expenses/expense-form/currency-utils.ts
+++ b/apps/web/src/app/groups/[groupId]/expenses/expense-form/currency-utils.ts
@@ -243,8 +243,12 @@ export function stepDisplayShares(value: unknown, direction: 1 | -1): number {
 }
 
 // Convert a Date to an ISO date string suitable for <input type="date" defaultValue>.
+export function isValidExpenseDate(date: unknown): date is Date {
+  return date instanceof Date && !Number.isNaN(date.getTime())
+}
+
 export function formatDate(date?: Date) {
-  const validDate = date && !Number.isNaN(date.getTime()) ? date : new Date()
+  const validDate = isValidExpenseDate(date) ? date : new Date()
   return validDate.toISOString().substring(0, 10)
 }
 

--- a/apps/web/src/app/groups/[groupId]/expenses/expense-form/index.tsx
+++ b/apps/web/src/app/groups/[groupId]/expenses/expense-form/index.tsx
@@ -34,6 +34,7 @@ import type {
   ReceiptScanContext,
 } from '../create-from-receipt-button'
 import { BasicDetailsCard } from './basic-details-card'
+import { formatDate, isValidExpenseDate } from './currency-utils'
 import { type SavedSplit } from './default-split/split-equal'
 import {
   buildExpenseFormDefaults,
@@ -289,7 +290,9 @@ export function ExpenseForm(props: {
   const receiptScanContext: ReceiptScanContext = {
     title: watchedTitle || undefined,
     amount: Number(watchedAmount) || undefined,
-    date: watchedExpenseDate?.toISOString().slice(0, 10),
+    date: isValidExpenseDate(watchedExpenseDate)
+      ? formatDate(watchedExpenseDate)
+      : undefined,
     currencyCode: originalCurrencyValue || groupCurrency.code,
     categoryId: watchedCategory || undefined,
     items: (watchedItems ?? []).map((item) => ({

--- a/apps/web/src/app/groups/[groupId]/expenses/expense-form/recurrence-schedule.ts
+++ b/apps/web/src/app/groups/[groupId]/expenses/expense-form/recurrence-schedule.ts
@@ -230,7 +230,8 @@ export function getRecurrencePreviewDates(
     .map(({ date }) => date)
 }
 
-export function formatDateInputValue(date: Date): string {
+export function formatDateInputValue(date: Date | undefined): string {
+  if (!date || Number.isNaN(date.getTime())) return ''
   return date.toISOString().slice(0, 10)
 }
 

--- a/apps/web/src/app/groups/[groupId]/expenses/expense-form/recurrence-section.tsx
+++ b/apps/web/src/app/groups/[groupId]/expenses/expense-form/recurrence-section.tsx
@@ -570,7 +570,7 @@ export function RecurrenceSection<T extends RecurrenceFormValues>({
                             })
                           }}
                           onBlur={() => setEndDateDraft(null)}
-                          className="mt-1"
+                          className="date-base mt-1"
                         />
                       </div>
                     )}


### PR DESCRIPTION
## Summary

Fix the datepicker not showing on dark mode + the capability of type 0 or backspace when using keyboard only

## Changes

Fix the UI & UX so we achieve the above

## Verification

- [x] `bun run check`
- [x] `bun run test`
- [ ] I added or updated tests where appropriate.

## AI-assisted development disclosure

<!-- AI agent contributions are welcome. If AI was used, choose one of the two
     options below and include the requested material. Redact secrets and
     private data from prompts. -->

- [ ] No AI assistance was used.
- [x] AI was used, and I included the initial prompt plus all materially
      relevant follow-up prompts below (with notes on important changes or
      decisions).
- [ ] AI was used for a new feature or larger change, and this PR includes a
      well-defined, up-to-date [OpenSpec](https://github.com/Fission-AI/OpenSpec/)
      instead of prompt history:
      <!-- Link to the OpenSpec here. -->

### Prompt history or OpenSpec link

Fix the expense form date picker (type="date"):

Typing 0 — editing day/month segments (e.g. 01, 07) doesn’t work
Backspace — can’t clear or edit date segments properly
Focus — field loses focus while typing
Calendar icon — not visible in dark mode on:
main expense date field
recurrence end date (#recurrence-end-date)
Constraints:

Keep native type="date" only — no extra calendar button
Match existing form patterns (React Hook Form)
Don’t over-engineer — no custom date parsing/masking unless needed
Fix icon for all date inputs in the app, not just one field


## Checklist

- [x] The implementation is complete and I have reviewed all AI-generated code.
- [x] Documentation is updated when needed.
- [x] Schema changes include the schema, migration, and generated client.
- [x] This PR contains one logical change.
- [x] Related issue: `Closes #62 `


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expense date entry across browsers, including light and dark themes.
  * Preserved valid dates when users enter, clear, or leave the date field.
  * Prevented invalid dates from causing errors during receipt scanning and recurring expense setup.
  * Improved recurrence end-date input styling and calendar controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->