### PR TITLE
feat: count negative expenses in stats and budgets

### DIFF
--- a/apps/api/src/trpc/routers/groups/stats/dashboard.test.ts
+++ b/apps/api/src/trpc/routers/groups/stats/dashboard.test.ts
@@ -80,7 +80,7 @@ describe('buildGroupStatsDashboard', () => {
     ])
   })
 
-  it('excludes reimbursements and non-positive expenses from spending visuals', () => {
+  it('excludes reimbursements and nets non-positive expenses in spending visuals', () => {
     const reimbursement = expense('reimbursement', '2024-06-05', 900, 'payment')
     reimbursement.isReimbursement = true
     const refund = expense('refund', '2024-06-06', -200, 'groceries')
@@ -94,10 +94,80 @@ describe('buildGroupStatsDashboard', () => {
       'WEEK',
     )
 
-    expect(dashboard.lifetimeTotal).toBe(1500)
-    expect(dashboard.period?.expenseCount).toBe(1)
+    expect(dashboard.lifetimeTotal).toBe(1300)
+    expect(dashboard.period?.expenseCount).toBe(2)
+    expect(dashboard.period?.total).toBe(1300)
     expect(dashboard.categories).toEqual([
-      expect.objectContaining({ categoryId: 'groceries', amount: 1500 }),
+      expect.objectContaining({
+        categoryId: 'groceries',
+        amount: 1300,
+        percentage: 1300 / 1500,
+      }),
+    ])
+  })
+
+  it('keeps a refund-only period and percentages against gross positive spend', () => {
+    const dashboard = buildGroupStatsDashboard(
+      [
+        expense('groceries', '2024-06-07', 1500, 'groceries'),
+        expense('income', '2024-06-07', -200, 'income'),
+      ],
+      'WEEK',
+    )
+
+    expect(dashboard.lifetimeTotal).toBe(1300)
+    expect(dashboard.period?.expenseCount).toBe(2)
+    expect(dashboard.categories).toEqual([
+      expect.objectContaining({
+        categoryId: 'groceries',
+        amount: 1500,
+        percentage: 1,
+      }),
+      expect.objectContaining({
+        categoryId: 'income',
+        amount: -200,
+        percentage: -200 / 1500,
+      }),
+    ])
+  })
+
+  it('keeps a net-zero bucket when spend and refund offset', () => {
+    const dashboard = buildGroupStatsDashboard(
+      [
+        expense('spend', '2024-06-07', 1500, 'groceries'),
+        expense('refund', '2024-06-07', -1500, 'groceries'),
+      ],
+      'LATEST_ACTIVITY',
+    )
+
+    expect(dashboard.period?.total).toBe(0)
+    expect(dashboard.period?.expenseCount).toBe(2)
+    expect(dashboard.timeline).toEqual([
+      expect.objectContaining({
+        type: 'bucket',
+        total: 0,
+        categories: [
+          expect.objectContaining({ categoryId: 'groceries', amount: 0 }),
+        ],
+      }),
+    ])
+  })
+
+  it('reports a refund-only period instead of empty stats', () => {
+    const dashboard = buildGroupStatsDashboard(
+      [expense('refund', '2024-06-07', -200, 'groceries')],
+      'WEEK',
+    )
+
+    expect(dashboard.lifetimeTotal).toBe(-200)
+    expect(dashboard.period?.expenseCount).toBe(1)
+    expect(dashboard.period?.total).toBe(-200)
+    expect(dashboard.categories).toEqual([
+      expect.objectContaining({
+        categoryId: 'groceries',
+        amount: -200,
+        percentage: -1,
+      }),
     ])
   })
 

--- a/apps/api/src/trpc/routers/groups/stats/dashboard.ts
+++ b/apps/api/src/trpc/routers/groups/stats/dashboard.ts
@@ -185,19 +185,35 @@ function rangeFor(
   }
 }
 
+function bucketHasActivity(bucket: Bucket | undefined): boolean {
+  return (bucket?.categories.length ?? 0) > 0
+}
+
+function signedPercentage(
+  amount: number,
+  grossPositive: number,
+  absFallback: number,
+): number {
+  if (grossPositive !== 0) return amount / grossPositive
+  if (absFallback === 0) return 0
+  return amount / absFallback
+}
+
 function collapseInactiveBuckets(buckets: Bucket[]): Array<Bucket | Gap> {
   const timeline: Array<Bucket | Gap> = []
 
   for (let index = 0; index < buckets.length;) {
     const bucket = buckets[index]
-    if (bucket.total !== 0) {
+    if (bucketHasActivity(bucket)) {
       timeline.push(bucket)
       index += 1
       continue
     }
 
     const emptyStart = index
-    while (index < buckets.length && buckets[index].total === 0) index += 1
+    while (index < buckets.length && !bucketHasActivity(buckets[index])) {
+      index += 1
+    }
     const emptyCount = index - emptyStart
     if (emptyCount === 1) {
       timeline.push(bucket)
@@ -219,9 +235,7 @@ export function buildGroupStatsDashboard(
   period: StatsPeriod,
   customRange?: StatsCustomRange,
 ) {
-  const expenses = rows.filter(
-    (expense) => !expense.isReimbursement && expense.amount > 0,
-  )
+  const expenses = rows.filter((expense) => !expense.isReimbursement)
   const lifetimeTotal = expenses.reduce(
     (total, expense) => total + expense.amount,
     0,
@@ -296,9 +310,7 @@ export function buildGroupStatsDashboard(
       })
   }
 
-  const nonEmptyBuckets = Array.from(buckets.values()).filter(
-    (bucket) => bucket.total > 0,
-  )
+  const nonEmptyBuckets = Array.from(buckets.values()).filter(bucketHasActivity)
   const firstBucket = nonEmptyBuckets[0]?.start
   const lastBucket = nonEmptyBuckets.at(-1)?.start
   const visibleBuckets = Array.from(buckets.values()).filter((bucket) =>
@@ -310,7 +322,31 @@ export function buildGroupStatsDashboard(
     (total, expense) => total + expense.amount,
     0,
   )
+  const grossPositive = selectedExpenses.reduce(
+    (total, expense) => total + (expense.amount > 0 ? expense.amount : 0),
+    0,
+  )
   const balances = getBalances(selectedExpenses)
+  const categories = Array.from(categoryTotals, ([categoryId, amount]) => ({
+    categoryId,
+    amount,
+  }))
+  const categoryAbsTotal = categories.reduce(
+    (total, category) => total + Math.abs(category.amount),
+    0,
+  )
+  const participants = Object.entries(balances)
+    .map(([participantId, balance]) => ({
+      participantId,
+      name: participantNames.get(participantId) ?? '',
+      account: participantAccounts.get(participantId) ?? null,
+      amount: balance.paidFor,
+    }))
+    .filter((participant) => participant.amount !== 0)
+  const participantAbsTotal = participants.reduce(
+    (total, participant) => total + Math.abs(participant.amount),
+    0,
+  )
 
   return {
     lifetimeTotal,
@@ -322,20 +358,25 @@ export function buildGroupStatsDashboard(
       expenseCount: selectedExpenses.length,
     },
     timeline: collapseInactiveBuckets(visibleBuckets),
-    categories: Array.from(categoryTotals, ([categoryId, amount]) => ({
-      categoryId,
-      amount,
-      percentage: selectedTotal === 0 ? 0 : amount / selectedTotal,
-    })).sort((a, b) => b.amount - a.amount),
-    participants: Object.entries(balances)
-      .map(([participantId, balance]) => ({
-        participantId,
-        name: participantNames.get(participantId) ?? '',
-        account: participantAccounts.get(participantId) ?? null,
-        amount: balance.paidFor,
-        percentage: selectedTotal === 0 ? 0 : balance.paidFor / selectedTotal,
+    categories: categories
+      .map((category) => ({
+        ...category,
+        percentage: signedPercentage(
+          category.amount,
+          grossPositive,
+          categoryAbsTotal,
+        ),
       }))
-      .filter((participant) => participant.amount > 0)
+      .sort((a, b) => b.amount - a.amount),
+    participants: participants
+      .map((participant) => ({
+        ...participant,
+        percentage: signedPercentage(
+          participant.amount,
+          grossPositive,
+          participantAbsTotal,
+        ),
+      }))
       .sort((a, b) => b.amount - a.amount),
   }
 }

--- a/apps/web/src/app/groups/[groupId]/expenses/category-icon.tsx
+++ b/apps/web/src/app/groups/[groupId]/expenses/category-icon.tsx
@@ -40,6 +40,7 @@ import {
   Train,
   Trash,
   Utensils,
+  Wallet,
   Wine,
   Wrench,
 } from 'lucide-react'
@@ -66,6 +67,8 @@ function getCategoryIcon(category: string): LucideIcon {
       return Banknote
     case 'Uncategorized/Payment':
       return Banknote
+    case 'Income/Income':
+      return Wallet
     case 'Entertainment/Entertainment':
       return FerrisWheel
     case 'Entertainment/Games':

--- a/apps/web/src/app/groups/[groupId]/expenses/tests/CategoryIcon.test.tsx
+++ b/apps/web/src/app/groups/[groupId]/expenses/tests/CategoryIcon.test.tsx
@@ -38,4 +38,12 @@ describe('CategoryIcon', () => {
     expect(svg).toHaveClass('lucide-clapperboard')
     expect(svg).toHaveClass('w-5 h-5')
   })
+
+  it('renders the Wallet icon for Income', () => {
+    const { container } = render(
+      <CategoryIcon category={{ grouping: 'Income', name: 'Income' }} />,
+    )
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveClass('lucide-wallet')
+  })
 })

--- a/apps/web/src/app/groups/[groupId]/stats/category-breakdown.tsx
+++ b/apps/web/src/app/groups/[groupId]/stats/category-breakdown.tsx
@@ -74,7 +74,7 @@ export function CategoryBreakdown({ data, currency }: Props) {
                 <div
                   className="h-full rounded-full"
                   style={{
-                    width: `${Math.max(category.percentage * 100, 3)}%`,
+                    width: `${Math.max(Math.abs(category.percentage) * 100, 3)}%`,
                     backgroundColor: getCategoryColor(index),
                   }}
                 />

--- a/apps/web/src/app/groups/[groupId]/stats/participant-breakdown.tsx
+++ b/apps/web/src/app/groups/[groupId]/stats/participant-breakdown.tsx
@@ -61,7 +61,7 @@ export function ParticipantBreakdown({ data, currency }: Props) {
                 <div
                   className="h-full rounded-full bg-primary"
                   style={{
-                    width: `${Math.max(participant.percentage * 100, 3)}%`,
+                    width: `${Math.max(Math.abs(participant.percentage) * 100, 3)}%`,
                     opacity: 1 - index * 0.07,
                   }}
                 />

--- a/apps/web/src/app/groups/[groupId]/stats/spending-chart-impl.tsx
+++ b/apps/web/src/app/groups/[groupId]/stats/spending-chart-impl.tsx
@@ -220,7 +220,7 @@ export function SpendingChart({ data, currency }: Props) {
         <div className="space-y-1.5">
           {payload.map((item) => {
             const amount = Number(item.value ?? 0)
-            if (amount <= 0) return null
+            if (amount === 0) return null
             const categoryId =
               typeof item.dataKey === 'string' ? item.dataKey : undefined
             const category = categories.find(

--- a/apps/web/src/components/category-selector.tsx
+++ b/apps/web/src/components/category-selector.tsx
@@ -350,6 +350,7 @@ function buildHierarchy(categories: ReadonlyArray<Category>): Hierarchy {
 
 const CATEGORY_GROUPING_HEADINGS = {
   Uncategorized: 'Uncategorized.heading',
+  Income: 'Income.heading',
   Entertainment: 'Entertainment.heading',
   'Food and Drink': 'Food and Drink.heading',
   Home: 'Home.heading',

--- a/apps/web/src/messages/ar-SA.json
+++ b/apps/web/src/messages/ar-SA.json
@@ -1554,6 +1554,9 @@
       "Water": "ماء",
       "Electricity": "كهرباء",
       "Cleaning": "تنظيف"
+    },
+    "Income": {
+      "heading": "دخل"
     }
   },
   "AccountSettings": {

--- a/apps/web/src/messages/bn-BD.json
+++ b/apps/web/src/messages/bn-BD.json
@@ -599,6 +599,9 @@
       "Trash": "আবর্জনা",
       "TV/Phone/Internet": "টিভি/ফোন/ইন্টারনেট",
       "Water": "পানি"
+    },
+    "Income": {
+      "heading": "আয়"
     }
   },
   "Common": {

--- a/apps/web/src/messages/ca.json
+++ b/apps/web/src/messages/ca.json
@@ -1321,6 +1321,9 @@
       "heading": "Subscripcions i membresies",
       "Digital Subscriptions": "Subscripcions digitals",
       "Memberships": "Membresies"
+    },
+    "Income": {
+      "heading": "Ingressos"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/cs-CZ.json
+++ b/apps/web/src/messages/cs-CZ.json
@@ -1329,6 +1329,9 @@
       "heading": "Předplatné a členství",
       "Digital Subscriptions": "Digitální předplatné",
       "Memberships": "Členství"
+    },
+    "Income": {
+      "heading": "Příjmy"
     }
   },
   "Auth": {

--- a/apps/web/src/messages/de-DE.json
+++ b/apps/web/src/messages/de-DE.json
@@ -1345,6 +1345,9 @@
       "heading": "Abonnements und Mitgliedschaften",
       "Digital Subscriptions": "Digitale Abonnements",
       "Memberships": "Mitgliedschaften"
+    },
+    "Income": {
+      "heading": "Einnahmen"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/en-GZ.json
+++ b/apps/web/src/messages/en-GZ.json
@@ -766,6 +766,9 @@
       "Trash": "trash day",
       "TV/Phone/Internet": "TV, phone, or internet",
       "Water": "water bill"
+    },
+    "Income": {
+      "heading": "money in"
     }
   },
   "Common": {

--- a/apps/web/src/messages/en-US.json
+++ b/apps/web/src/messages/en-US.json
@@ -1761,6 +1761,9 @@
     },
     "Personal Care and Wellness": {
       "heading": "Personal Care and Wellness"
+    },
+    "Income": {
+      "heading": "Income"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1321,6 +1321,9 @@
       "heading": "Suscripciones y membresías",
       "Digital Subscriptions": "Suscripciones digitales",
       "Memberships": "Membresías"
+    },
+    "Income": {
+      "heading": "Ingresos"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/eu.json
+++ b/apps/web/src/messages/eu.json
@@ -1321,6 +1321,9 @@
       "heading": "Harpidetzak eta kidetzak",
       "Digital Subscriptions": "Harpidetza digitalak",
       "Memberships": "Kidetzak"
+    },
+    "Income": {
+      "heading": "Diru-sarrerak"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/fi.json
+++ b/apps/web/src/messages/fi.json
@@ -1313,6 +1313,9 @@
       "heading": "Tilaukset ja jäsenyydet",
       "Digital Subscriptions": "Digitaaliset tilaukset",
       "Memberships": "Jäsenyydet"
+    },
+    "Income": {
+      "heading": "Tulot"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/fr-FR.json
+++ b/apps/web/src/messages/fr-FR.json
@@ -1321,6 +1321,9 @@
       "heading": "Abonnements et adhésions",
       "Digital Subscriptions": "Abonnements numériques",
       "Memberships": "Adhésions"
+    },
+    "Income": {
+      "heading": "Revenus"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/he.json
+++ b/apps/web/src/messages/he.json
@@ -1321,6 +1321,9 @@
       "heading": "מינויים וחברויות",
       "Digital Subscriptions": "מינויים דיגיטליים",
       "Memberships": "חברויות"
+    },
+    "Income": {
+      "heading": "הכנסה"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/hi-IN.json
+++ b/apps/web/src/messages/hi-IN.json
@@ -599,6 +599,9 @@
       "Trash": "कचरा",
       "TV/Phone/Internet": "टीवी/फ़ोन/इंटरनेट",
       "Water": "पानी"
+    },
+    "Income": {
+      "heading": "आय"
     }
   },
   "Common": {

--- a/apps/web/src/messages/id.json
+++ b/apps/web/src/messages/id.json
@@ -1615,6 +1615,9 @@
       "heading": "Langganan dan Keanggotaan",
       "Digital Subscriptions": "Langganan digital",
       "Memberships": "Keanggotaan"
+    },
+    "Income": {
+      "heading": "Pemasukan"
     }
   },
   "Auth": {

--- a/apps/web/src/messages/it-IT.json
+++ b/apps/web/src/messages/it-IT.json
@@ -1321,6 +1321,9 @@
       "heading": "Abbonamenti e iscrizioni",
       "Digital Subscriptions": "Abbonamenti digitali",
       "Memberships": "Iscrizioni"
+    },
+    "Income": {
+      "heading": "Entrate"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/ja-JP.json
+++ b/apps/web/src/messages/ja-JP.json
@@ -1306,6 +1306,9 @@
       "heading": "サブスクリプションと会員費",
       "Digital Subscriptions": "デジタルサブスクリプション",
       "Memberships": "会員費"
+    },
+    "Income": {
+      "heading": "収入"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/ko.json
+++ b/apps/web/src/messages/ko.json
@@ -1139,6 +1139,9 @@
       "heading": "구독 및 멤버십",
       "Digital Subscriptions": "디지털 구독",
       "Memberships": "멤버십"
+    },
+    "Income": {
+      "heading": "수입"
     }
   },
   "Homepage": {

--- a/apps/web/src/messages/mk-MK.json
+++ b/apps/web/src/messages/mk-MK.json
@@ -1652,6 +1652,9 @@
       "heading": "Претплати и членарини",
       "Digital Subscriptions": "Дигитални претплати",
       "Memberships": "Членарини"
+    },
+    "Income": {
+      "heading": "Приход"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/nl-NL.json
+++ b/apps/web/src/messages/nl-NL.json
@@ -1313,6 +1313,9 @@
       "heading": "Abonnementen en lidmaatschappen",
       "Digital Subscriptions": "Digitale abonnementen",
       "Memberships": "Lidmaatschappen"
+    },
+    "Income": {
+      "heading": "Inkomsten"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/pl-PL.json
+++ b/apps/web/src/messages/pl-PL.json
@@ -1329,6 +1329,9 @@
       "heading": "Subskrypcje i członkostwa",
       "Digital Subscriptions": "Subskrypcje cyfrowe",
       "Memberships": "Członkostwa"
+    },
+    "Income": {
+      "heading": "Przychody"
     }
   },
   "Auth": {

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1321,6 +1321,9 @@
       "heading": "Assinaturas e associações",
       "Digital Subscriptions": "Assinaturas digitais",
       "Memberships": "Associações"
+    },
+    "Income": {
+      "heading": "Receitas"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/pt.json
+++ b/apps/web/src/messages/pt.json
@@ -1428,6 +1428,9 @@
       "heading": "Assinaturas e filiações",
       "Digital Subscriptions": "Assinaturas digitais",
       "Memberships": "Filiações"
+    },
+    "Income": {
+      "heading": "Rendimentos"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/ro.json
+++ b/apps/web/src/messages/ro.json
@@ -1321,6 +1321,9 @@
       "heading": "Abonamente și membri",
       "Digital Subscriptions": "Abonamente digitale",
       "Memberships": "Membri"
+    },
+    "Income": {
+      "heading": "Venituri"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/ru-RU.json
+++ b/apps/web/src/messages/ru-RU.json
@@ -1329,6 +1329,9 @@
       "heading": "Подписки и членство",
       "Digital Subscriptions": "Цифровые подписки",
       "Memberships": "Членство"
+    },
+    "Income": {
+      "heading": "Доход"
     }
   },
   "Auth": {

--- a/apps/web/src/messages/sv-SE.json
+++ b/apps/web/src/messages/sv-SE.json
@@ -599,6 +599,9 @@
       "Trash": "Sophämtning",
       "TV/Phone/Internet": "TV/Telefon/Internet",
       "Water": "Vatten"
+    },
+    "Income": {
+      "heading": "Inkomst"
     }
   },
   "Common": {

--- a/apps/web/src/messages/tr-TR.json
+++ b/apps/web/src/messages/tr-TR.json
@@ -1313,6 +1313,9 @@
       "heading": "Abonelikler ve Üyelikler",
       "Digital Subscriptions": "Dijital Abonelikler",
       "Memberships": "Üyelikler"
+    },
+    "Income": {
+      "heading": "Gelir"
     }
   },
   "Auth": {

--- a/apps/web/src/messages/uk-UA.json
+++ b/apps/web/src/messages/uk-UA.json
@@ -1329,6 +1329,9 @@
       "heading": "Підписки та членство",
       "Digital Subscriptions": "Цифрові підписки",
       "Memberships": "Членство"
+    },
+    "Income": {
+      "heading": "Дохід"
     }
   },
   "Auth": {

--- a/apps/web/src/messages/ur-PK.json
+++ b/apps/web/src/messages/ur-PK.json
@@ -599,6 +599,9 @@
       "Trash": "کوڑا کرکٹ",
       "TV/Phone/Internet": "TV/فون/انٹرنیٹ",
       "Water": "پانی"
+    },
+    "Income": {
+      "heading": "آمدنی"
     }
   },
   "Common": {

--- a/apps/web/src/messages/vi.json
+++ b/apps/web/src/messages/vi.json
@@ -1761,6 +1761,9 @@
     },
     "Personal Care and Wellness": {
       "heading": "Chăm sóc cá nhân"
+    },
+    "Income": {
+      "heading": "Thu nhập"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/zh-CN.json
+++ b/apps/web/src/messages/zh-CN.json
@@ -1306,6 +1306,9 @@
       "heading": "订阅与会员",
       "Digital Subscriptions": "数字订阅",
       "Memberships": "会员"
+    },
+    "Income": {
+      "heading": "收入"
     }
   },
   "Currencies": {

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -1306,6 +1306,9 @@
       "heading": "訂閱與會員",
       "Digital Subscriptions": "數位訂閱",
       "Memberships": "會員"
+    },
+    "Income": {
+      "heading": "收入"
     }
   },
   "Auth": {

--- a/packages/domain/src/budgets.test.ts
+++ b/packages/domain/src/budgets.test.ts
@@ -146,7 +146,7 @@ describe('period bounds', () => {
 })
 
 describe('calculateExpenseContribution exclusions', () => {
-  it('ignores reimbursements and non-positive amounts', () => {
+  it('ignores reimbursements and zero amounts', () => {
     expect(
       calculateExpenseContribution(
         rule,
@@ -157,9 +157,68 @@ describe('calculateExpenseContribution exclusions', () => {
     expect(
       calculateExpenseContribution(rule, expense({ amount: 0 }), julBounds),
     ).toBe(0)
+  })
+
+  it('counts negative matching amounts toward usage', () => {
+    const allParticipants: BudgetRule = { ...rule, participantScope: 'ALL' }
     expect(
-      calculateExpenseContribution(rule, expense({ amount: -500 }), julBounds),
+      calculateExpenseContribution(
+        allParticipants,
+        expense({ amount: -500, categoryId: 'groceries' }),
+        julBounds,
+      ),
+    ).toBe(-500)
+  })
+
+  it('nets a groceries refund against groceries spend', () => {
+    const groceries: BudgetRule = {
+      ...rule,
+      participantScope: 'ALL',
+      categoryScope: 'SELECTED',
+      categoryNodeIds: ['groceries'],
+    }
+    expect(
+      calculateBudgetUsage(
+        groceries,
+        [
+          expense({ amount: 5000, categoryId: 'groceries' }),
+          expense({ id: 'e2', amount: -500, categoryId: 'groceries' }),
+        ],
+        julBounds,
+        { categoryMatches: taxonomyMatches },
+      ),
+    ).toBe(4500)
+  })
+
+  it('ignores Income-categorized amounts on a groceries budget', () => {
+    const groceries: BudgetRule = {
+      ...rule,
+      participantScope: 'ALL',
+      categoryScope: 'SELECTED',
+      categoryNodeIds: ['groceries'],
+    }
+    expect(
+      calculateExpenseContribution(
+        groceries,
+        expense({ amount: -2000, categoryId: 'income' }),
+        julBounds,
+        { categoryMatches: taxonomyMatches },
+      ),
     ).toBe(0)
+  })
+
+  it('nets income on an all-categories budget', () => {
+    const allCategories: BudgetRule = { ...rule, participantScope: 'ALL' }
+    expect(
+      calculateBudgetUsage(
+        allCategories,
+        [
+          expense({ amount: 5000, categoryId: 'groceries' }),
+          expense({ id: 'e2', amount: -2000, categoryId: 'income' }),
+        ],
+        julBounds,
+      ),
+    ).toBe(3000)
   })
 
   it('ignores expenses outside the period bounds', () => {

--- a/packages/domain/src/budgets.ts
+++ b/packages/domain/src/budgets.ts
@@ -128,12 +128,12 @@ export type BudgetUsageOptions = {
 /**
  * Contribution of a single expense toward a budget period, in integer cents.
  *
- * Returns 0 when the expense is excluded: reimbursements and non-positive
- * amounts, dates outside the period bounds, categories outside a SELECTED
- * scope, and shares owed by participants outside a SELECTED scope. Otherwise it
- * sums the selected participants' calculated owed shares, reusing the shared
- * split calculation (even, shares, basis-point percentages, explicit amounts,
- * cross-currency, and itemized expenses).
+ * Returns 0 when the expense is excluded: reimbursements and zero amounts,
+ * dates outside the period bounds, categories outside a SELECTED scope, and
+ * shares owed by participants outside a SELECTED scope. Otherwise it sums the
+ * selected participants' calculated owed shares, reusing the shared split
+ * calculation (even, shares, basis-point percentages, explicit amounts,
+ * cross-currency, and itemized expenses). Negative amounts reduce usage.
  */
 export function dateOnlyInBudgetZone(instant: Date, timeZone: string): Date {
   const parts = new Intl.DateTimeFormat('en-US', {
@@ -165,7 +165,7 @@ export function calculateExpenseContribution(
   bounds: BudgetPeriodBounds,
   options: BudgetUsageOptions = {},
 ): number {
-  if (expense.isReimbursement || expense.amount <= 0) return 0
+  if (expense.isReimbursement || expense.amount === 0) return 0
   const date = expenseDateInBudgetZone(expense, rule.timeZone)
   if (!date || Number.isNaN(date.getTime())) return 0
   if (date < bounds.start || date > bounds.end) return 0
@@ -193,8 +193,8 @@ export function calculateExpenseContribution(
 }
 
 /**
- * Calculates selected paid-for shares, excluding reimbursements and negative
- * amounts.
+ * Calculates selected paid-for shares, excluding reimbursements and zero
+ * amounts. Negative amounts reduce usage.
  */
 export function calculateBudgetUsage(
   rule: BudgetRule,

--- a/packages/domain/src/categories.test.ts
+++ b/packages/domain/src/categories.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_CATEGORIES,
   DEFAULT_CATEGORY_ID,
   DEFAULT_GROUPINGS,
+  INCOME_CATEGORY_ID,
   PARENT_CATEGORIES,
   PAYMENT_CATEGORY_ID,
   categoryIdSchema,
@@ -33,6 +34,12 @@ describe('DEFAULT_CATEGORIES', () => {
   it('keeps the legacy default and payment ids', () => {
     expect(getCategoryById(DEFAULT_CATEGORY_ID)?.name).toBe('General')
     expect(getCategoryById(PAYMENT_CATEGORY_ID)?.name).toBe('Payment')
+    expect(getCategoryById(INCOME_CATEGORY_ID)).toEqual({
+      id: 'income',
+      grouping: 'Income',
+      name: 'Income',
+      parentId: null,
+    })
   })
 
   it('has a parent for every declared grouping', () => {

--- a/packages/domain/src/categories.ts
+++ b/packages/domain/src/categories.ts
@@ -71,6 +71,13 @@ export const DEFAULT_CATEGORIES = defineCategories([
     name: 'Payment',
     parentId: 'uncategorized',
   },
+  // Income
+  {
+    id: 'income',
+    grouping: 'Income',
+    name: 'Income',
+    parentId: null,
+  },
   // Entertainment
   {
     id: 'entertainment',
@@ -335,6 +342,9 @@ export const DEFAULT_CATEGORY_ID: CategoryId = 'general'
 
 /** Category used by reimbursement-style expenses (manual or auto). */
 export const PAYMENT_CATEGORY_ID: CategoryId = 'payment'
+
+/** Category used for true income (negative amounts that are not refunds). */
+export const INCOME_CATEGORY_ID: CategoryId = 'income'
 
 /** Parent categories in declaration order. */
 export const PARENT_CATEGORIES = DEFAULT_CATEGORIES.filter(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Negative expense amounts are already valid (refunds and income) and already shift balances, but group stats and budgets ignored anything ≤ 0. This nets signed non-reimbursement amounts against the expense’s stored category, and adds a built-in Income category for true income.

## Changes

- Stats dashboard (`buildGroupStatsDashboard`) includes signed non-reimbursement amounts in lifetime, period, category, timeline, and participant totals.
- Category/participant percentages use gross positive spend; bars size from `abs(percentage)`.
- Timeline keeps refund-only and net-zero buckets that still have category activity.
- Spending chart tooltip shows negative segments.
- Budget contribution counts negative matching amounts (reimbursements and zero amounts still contribute 0).
- New default parent category `income`, icon, picker grouping, and translations via `bun i18n`.
- Negative amounts do **not** auto-switch category to Income.

## Verification

- [x] Domain tests: budgets and categories (`887` passed)
- [x] Stats dashboard unit tests (`8` passed)
- [x] Category icon and selector tests
- [x] `check-types` and `lint` for domain, api, and web
- [x] `bun i18n check --changes-only`
- [ ] `bun run check` (full monorepo)
- [ ] `bun run test` (full monorepo)

## AI-assisted development disclosure

- [x] AI was used, and I included the initial prompt plus all materially relevant follow-up prompts below (with notes on important changes or decisions).

### Prompt history or OpenSpec link

Initial request: negative expenses can be entered but do not count negatively toward stats; they are used for income (maybe a custom income category) and more often for refunds or negating a previous expense.

Follow-up decisions: net against the chosen category; add a built-in Income category; also apply to budgets. Then: implement directly, no OpenSpec.

## Checklist

- [x] The implementation is complete and I have reviewed all AI-generated code.
- [x] Documentation is updated when needed.
- [x] Schema changes include the schema, migration, and generated client.
- [x] This PR contains one logical change.
- [ ] Related issue: `Closes #...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11af786e-1f4f-4c74-9bc4-5cde3a3bbbd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11af786e-1f4f-4c74-9bc4-5cde3a3bbbd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Income category across expense categorization and supported languages.
  * Added a wallet icon for Income categories.
  * Refunds and income now reduce totals and budget usage appropriately.

* **Bug Fixes**
  * Improved dashboard statistics for refunds, reimbursements, negative values, and zero-value periods.
  * Updated charts and breakdowns to display negative values and percentages correctly.
  * Income categories now appear correctly in category and participant summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->