### PR TITLE
chore: simple Abuse and Overload Protection

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -34,22 +34,21 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY:
-            ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          
+
           # for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
           # AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # AWS_REGION: us-east-1
           # BEDROCK_MODEL_ID: <bedrock-model-id>
-          
+
           # for Google Vertex AI (https://docs.pullfrog.com/vertex)
           # VERTEX_SERVICE_ACCOUNT_JSON: >-
           #   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}

--- a/apps/api/src/app.security.test.ts
+++ b/apps/api/src/app.security.test.ts
@@ -1,7 +1,11 @@
+import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 
 import './test/mocks'
-import { requestWithTrustedProxyHeaders } from './app'
+import {
+  clientRateLimitMiddleware,
+  requestWithTrustedProxyHeaders,
+} from './app'
 
 describe('proxy header trust', () => {
   it('removes client-supplied IP headers when proxy trust is disabled', () => {
@@ -20,5 +24,44 @@ describe('proxy header trust', () => {
     expect(sanitized.headers.get('x-forwarded-for')).toBeNull()
     expect(sanitized.headers.get('x-real-ip')).toBeNull()
     expect(sanitized.headers.get('x-request-id')).toBe('keep-me')
+  })
+
+  it('skips IP rate limiting when no proxy is trusted', async () => {
+    const testApp = new Hono()
+    testApp.use(
+      '/limited',
+      clientRateLimitMiddleware({
+        policy: 'test-untrusted-proxy',
+        limit: 1,
+        windowMs: 60_000,
+        trustProxy: false,
+      }),
+    )
+    testApp.get('/limited', (c) => c.text('ok'))
+
+    for (let count = 0; count < 3; count += 1) {
+      const response = await testApp.request('/limited', {
+        headers: { 'cf-connecting-ip': `203.0.113.${count + 1}` },
+      })
+      expect(response.status).toBe(200)
+    }
+  })
+
+  it('applies per-IP rate limiting when the proxy is trusted', async () => {
+    const testApp = new Hono()
+    testApp.use(
+      '/limited',
+      clientRateLimitMiddleware({
+        policy: 'test-trusted-proxy',
+        limit: 1,
+        windowMs: 60_000,
+        trustProxy: true,
+      }),
+    )
+    testApp.get('/limited', (c) => c.text('ok'))
+
+    const headers = { 'cf-connecting-ip': '203.0.113.10' }
+    expect((await testApp.request('/limited', { headers })).status).toBe(200)
+    expect((await testApp.request('/limited', { headers })).status).toBe(429)
   })
 })

--- a/apps/api/src/app.security.test.ts
+++ b/apps/api/src/app.security.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import './test/mocks'
+import { requestWithTrustedProxyHeaders } from './app'
+
+describe('proxy header trust', () => {
+  it('removes client-supplied IP headers when proxy trust is disabled', () => {
+    const request = new Request('https://api.example.test/auth/get-session', {
+      headers: {
+        'cf-connecting-ip': '203.0.113.1',
+        'x-forwarded-for': '203.0.113.2',
+        'x-real-ip': '203.0.113.3',
+        'x-request-id': 'keep-me',
+      },
+    })
+
+    const sanitized = requestWithTrustedProxyHeaders(request)
+
+    expect(sanitized.headers.get('cf-connecting-ip')).toBeNull()
+    expect(sanitized.headers.get('x-forwarded-for')).toBeNull()
+    expect(sanitized.headers.get('x-real-ip')).toBeNull()
+    expect(sanitized.headers.get('x-request-id')).toBe('keep-me')
+  })
+})

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,7 +9,7 @@ import {
 import { Scalar } from '@scalar/hono-api-reference'
 import { TRPCError } from '@trpc/server'
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
-import { Hono } from 'hono'
+import { Hono, type MiddlewareHandler } from 'hono'
 import { cors } from 'hono/cors'
 
 import { auth } from './lib/auth'
@@ -17,7 +17,11 @@ import { SIGNUP_INVITE_HEADER } from './lib/auth/signup-gate'
 import { env, webOrigins } from './lib/env'
 import { checkLiveness, checkReadiness } from './lib/health'
 import { logServerError, logServerWarn } from './lib/logging'
-import { FixedWindowLimiter, resolveClientIp } from './lib/rate-limit'
+import {
+  FixedWindowLimiter,
+  logRateLimitExceeded,
+  resolveClientIp,
+} from './lib/rate-limit'
 import { buildScalarConfig } from './lib/scalar-theme'
 import {
   emailUnsubscribeGet,
@@ -45,6 +49,15 @@ function isPublicOAuthProtocolPath(path: string) {
     path === '/auth/jwks' ||
     path.startsWith('/auth/oauth2/')
   )
+}
+
+export function requestWithTrustedProxyHeaders(request: Request): Request {
+  if (env.TRUST_PROXY) return request
+  const headers = new Headers(request.headers)
+  headers.delete('cf-connecting-ip')
+  headers.delete('x-forwarded-for')
+  headers.delete('x-real-ip')
+  return new Request(request, { headers })
 }
 
 // Centralised handler for any uncaught error outside `/trpc/*`. tRPC has its
@@ -96,6 +109,50 @@ const oauthRegistrationLimiter = new FixedWindowLimiter({
   limit: 20,
   windowMs: 60 * 60 * 1000,
 })
+
+function clientRateLimitMiddleware(options: {
+  policy: string
+  limit: number
+  windowMs: number
+}): MiddlewareHandler {
+  const limiter = new FixedWindowLimiter({
+    limit: options.limit,
+    windowMs: options.windowMs,
+  })
+  return async (c, next) => {
+    const ip = resolveClientIp(c.req.raw.headers, {
+      trustProxy: env.TRUST_PROXY,
+    })
+    const decision = limiter.hit(ip)
+    if (!decision.allowed) {
+      logRateLimitExceeded({
+        policy: options.policy,
+        identity: ip,
+        retryAfterSeconds: decision.retryAfterSeconds,
+        path: c.req.path,
+      })
+      return c.json(
+        { error: 'rate_limit_exceeded' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(decision.retryAfterSeconds) },
+        },
+      )
+    }
+    await next()
+  }
+}
+
+const exportRateLimit = clientRateLimitMiddleware({
+  policy: 'export',
+  limit: 60,
+  windowMs: 60 * 60 * 1000,
+})
+const reportRateLimit = clientRateLimitMiddleware({
+  policy: 'report-data',
+  limit: 120,
+  windowMs: 60 * 60 * 1000,
+})
 app.use('/auth/oauth2/register', async (c, next) => {
   const ip = resolveClientIp(c.req.raw.headers, {
     trustProxy: env.TRUST_PROXY,
@@ -119,7 +176,9 @@ app.get('/email/unsubscribe', emailUnsubscribeGet)
 app.post('/email/unsubscribe', emailUnsubscribePost)
 
 // better-auth handler — exposes /auth/sign-in, /auth/sign-up, etc.
-app.on(['GET', 'POST'], '/auth/*', (c) => auth.handler(c.req.raw))
+app.on(['GET', 'POST'], '/auth/*', (c) =>
+  auth.handler(requestWithTrustedProxyHeaders(c.req.raw)),
+)
 app.get('/.well-known/oauth-authorization-server', (c) =>
   env.ENABLE_MCP
     ? oauthProviderAuthServerMetadata(auth, {
@@ -149,15 +208,17 @@ app.get('/.well-known/openid-configuration/auth', (c) =>
     : c.notFound(),
 )
 
-app.get('/groups/:groupId/export/bundle', (c) =>
+app.get('/groups/:groupId/export/bundle', exportRateLimit, (c) =>
   exportGroupBundle(c.req.raw, c.req.param('groupId')),
 )
-app.post('/account/export/bundle', (c) => exportAccountBundle(c.req.raw))
-app.get('/groups/:groupId/expenses/export/csv', (c) =>
+app.post('/account/export/bundle', exportRateLimit, (c) =>
+  exportAccountBundle(c.req.raw),
+)
+app.get('/groups/:groupId/expenses/export/csv', exportRateLimit, (c) =>
   exportGroupCsv(c.req.raw, c.req.param('groupId')),
 )
 app.post('/imports/documents/file', (c) => proxyImportDocument(c.req.raw))
-app.post('/groups/:groupId/expenses/report-data', (c) =>
+app.post('/groups/:groupId/expenses/report-data', reportRateLimit, (c) =>
   reportGroupData(c.req.raw, c.req.param('groupId')),
 )
 
@@ -197,7 +258,8 @@ app.all('/trpc/*', (c) =>
     endpoint: '/trpc',
     req: c.req.raw,
     router: appRouter,
-    createContext: () => createTRPCContext({ req: c.req.raw }),
+    createContext: ({ resHeaders }) =>
+      createTRPCContext({ req: c.req.raw, resHeaders }),
     onError({ error, path, type, ctx }) {
       // Expected client errors are normal product behavior — logging them
       // would flood the console. Only log infrastructure failures (uncaught

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -105,23 +105,25 @@ app.get('/health', () => checkLiveness())
 app.get('/health/liveness', () => checkLiveness())
 app.get('/health/readiness', () => checkReadiness())
 
-const oauthRegistrationLimiter = new FixedWindowLimiter({
-  limit: 20,
-  windowMs: 60 * 60 * 1000,
-})
-
-function clientRateLimitMiddleware(options: {
+export function clientRateLimitMiddleware(options: {
   policy: string
   limit: number
   windowMs: number
+  trustProxy?: boolean
 }): MiddlewareHandler {
   const limiter = new FixedWindowLimiter({
     limit: options.limit,
     windowMs: options.windowMs,
   })
   return async (c, next) => {
+    const trustProxy = options.trustProxy ?? env.TRUST_PROXY
+    if (!trustProxy) {
+      await next()
+      return
+    }
+
     const ip = resolveClientIp(c.req.raw.headers, {
-      trustProxy: env.TRUST_PROXY,
+      trustProxy,
     })
     const decision = limiter.hit(ip)
     if (!decision.allowed) {
@@ -153,22 +155,12 @@ const reportRateLimit = clientRateLimitMiddleware({
   limit: 120,
   windowMs: 60 * 60 * 1000,
 })
-app.use('/auth/oauth2/register', async (c, next) => {
-  const ip = resolveClientIp(c.req.raw.headers, {
-    trustProxy: env.TRUST_PROXY,
-  })
-  const decision = oauthRegistrationLimiter.hit(ip)
-  if (!decision.allowed) {
-    return c.json(
-      { error: 'rate_limit_exceeded' },
-      {
-        status: 429,
-        headers: { 'Retry-After': String(decision.retryAfterSeconds) },
-      },
-    )
-  }
-  await next()
+const oauthRegistrationRateLimit = clientRateLimitMiddleware({
+  policy: 'oauth-registration',
+  limit: 20,
+  windowMs: 60 * 60 * 1000,
 })
+app.use('/auth/oauth2/register', oauthRegistrationRateLimit)
 
 // Public, stateless optional-email unsubscribe endpoint. GET only renders a
 // confirmation page; POST performs the RFC 8058 one-click mutation.

--- a/apps/api/src/lib/api/expenses/suggest-category.test.ts
+++ b/apps/api/src/lib/api/expenses/suggest-category.test.ts
@@ -36,12 +36,18 @@ beforeEach(() => {
 
 describe('suggestExpenseCategory', () => {
   it('returns a dictionary hit without querying titles or calling the model', async () => {
+    const beforeAi = vi.fn()
     await expect(
-      suggestExpenseCategory({ groupId: 'group-1', title: 'Whole Foods' }),
+      suggestExpenseCategory({
+        groupId: 'group-1',
+        title: 'Whole Foods',
+        beforeAi,
+      }),
     ).resolves.toEqual({ categoryId: 'groceries' })
     expect(prismaMock.group.findUnique).not.toHaveBeenCalled()
     expect(prisma$QueryRaw).not.toHaveBeenCalled()
     expect(generateText).not.toHaveBeenCalled()
+    expect(beforeAi).not.toHaveBeenCalled()
   })
 
   it('returns null for 1–2 letter titles without querying or calling the model', async () => {
@@ -97,14 +103,17 @@ describe('suggestExpenseCategory', () => {
 
   it('calls the model when local matching is weak and AI is allowed', async () => {
     envState.PUBLIC_ENABLE_CATEGORY_EXTRACT = true
+    const beforeAi = vi.fn()
 
     await expect(
       suggestExpenseCategory({
         groupId: 'group-1',
         title: 'Luigi mysterious trattoria xyzzy',
         allowAi: true,
+        beforeAi,
       }),
     ).resolves.toEqual({ categoryId: 'groceries' })
+    expect(beforeAi).toHaveBeenCalledOnce()
     expect(generateText).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/api/src/lib/api/expenses/suggest-category.test.ts
+++ b/apps/api/src/lib/api/expenses/suggest-category.test.ts
@@ -36,11 +36,13 @@ beforeEach(() => {
 
 describe('suggestExpenseCategory', () => {
   it('returns a dictionary hit without querying titles or calling the model', async () => {
+    envState.PUBLIC_ENABLE_CATEGORY_EXTRACT = true
     const beforeAi = vi.fn()
     await expect(
       suggestExpenseCategory({
         groupId: 'group-1',
         title: 'Whole Foods',
+        allowAi: true,
         beforeAi,
       }),
     ).resolves.toEqual({ categoryId: 'groceries' })
@@ -115,6 +117,9 @@ describe('suggestExpenseCategory', () => {
     ).resolves.toEqual({ categoryId: 'groceries' })
     expect(beforeAi).toHaveBeenCalledOnce()
     expect(generateText).toHaveBeenCalledTimes(1)
+    expect(beforeAi.mock.invocationCallOrder[0]).toBeLessThan(
+      generateText.mock.invocationCallOrder[0]!,
+    )
   })
 
   it('does not call the model when allowAi is false even if the flag is on', async () => {

--- a/apps/api/src/lib/api/expenses/suggest-category.ts
+++ b/apps/api/src/lib/api/expenses/suggest-category.ts
@@ -25,6 +25,8 @@ export type SuggestExpenseCategoryArgs = {
    * PUBLIC_ENABLE_CATEGORY_EXTRACT.
    */
   allowAi?: boolean
+  /** Invoked immediately before the provider fallback, after local misses. */
+  beforeAi?: () => void
 }
 
 /**
@@ -73,6 +75,8 @@ export async function suggestExpenseCategory(
   if (!args.allowAi || !env.PUBLIC_ENABLE_CATEGORY_EXTRACT) {
     return { categoryId: null }
   }
+
+  args.beforeAi?.()
 
   let recentExpenses = similar.map((row) => ({
     title: row.title,

--- a/apps/api/src/lib/auth/index.test.ts
+++ b/apps/api/src/lib/auth/index.test.ts
@@ -59,6 +59,9 @@ const realAuthModule = (await vi.importActual('./index')) as {
           trustedProviders?: string[]
         }
       }
+      advanced?: {
+        ipAddress?: { ipAddressHeaders?: string[] }
+      }
       socialProviders?: Record<
         string,
         {
@@ -109,6 +112,12 @@ describe('better-auth session config', () => {
     )
 
     expect(jwtPlugin?.options?.disableSettingJwtHeader).toBe(true)
+  })
+
+  it('checks Cloudflare and conventional proxy IP headers in order', () => {
+    expect(
+      realAuthModule.auth.options.advanced?.ipAddress?.ipAddressHeaders,
+    ).toEqual(['cf-connecting-ip', 'x-real-ip', 'x-forwarded-for'])
   })
 
   it('uses an isolated JWKS adapter in the test environment', () => {

--- a/apps/api/src/lib/auth/index.test.ts
+++ b/apps/api/src/lib/auth/index.test.ts
@@ -41,7 +41,13 @@ const realAuthModule = (await vi.importActual('./index')) as {
           adapter?: unknown
         }
       }>
-      emailVerification?: { autoSignInAfterVerification?: boolean }
+      emailVerification?: {
+        autoSignInAfterVerification?: boolean
+        sendVerificationEmail?: (params: {
+          user: { id: string; email: string }
+          url: string
+        }) => Promise<void>
+      }
       session?: {
         expiresIn?: number
         updateAge?: number
@@ -172,6 +178,33 @@ describe('better-auth emailVerification config', () => {
       realAuthModule.auth.options.emailVerification
         ?.autoSignInAfterVerification,
     ).toBe(true)
+  })
+
+  it('charges recipient quota only from the email delivery callback', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const sendVerificationEmail =
+      realAuthModule.auth.options.emailVerification?.sendVerificationEmail
+    expect(sendVerificationEmail).toBeDefined()
+    const params = {
+      user: {
+        id: 'recipient-delivery-limit-account',
+        email: 'recipient-delivery-limit@example.test',
+      },
+      url: 'https://example.test/verify',
+    }
+
+    for (let count = 0; count < 10; count += 1) {
+      await expect(sendVerificationEmail?.(params)).resolves.toBeUndefined()
+    }
+    await expect(sendVerificationEmail?.(params)).rejects.toMatchObject({
+      status: 'TOO_MANY_REQUESTS',
+      body: { code: 'EMAIL_RATE_LIMIT_EXCEEDED' },
+    })
+
+    expect(sendEmailMock).toHaveBeenCalledTimes(10)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('auth-email-recipient'),
+    )
   })
 })
 

--- a/apps/api/src/lib/auth/index.test.ts
+++ b/apps/api/src/lib/auth/index.test.ts
@@ -60,8 +60,12 @@ const realAuthModule = (await vi.importActual('./index')) as {
         }
       }
       advanced?: {
-        ipAddress?: { ipAddressHeaders?: string[] }
+        ipAddress?: {
+          ipAddressHeaders?: string[]
+          disableIpTracking?: boolean
+        }
       }
+      rateLimit?: { enabled?: boolean }
       socialProviders?: Record<
         string,
         {
@@ -118,6 +122,13 @@ describe('better-auth session config', () => {
     expect(
       realAuthModule.auth.options.advanced?.ipAddress?.ipAddressHeaders,
     ).toEqual(['cf-connecting-ip', 'x-real-ip', 'x-forwarded-for'])
+  })
+
+  it('disables built-in IP tracking and throttling without a trusted proxy', () => {
+    expect(realAuthModule.auth.options.rateLimit?.enabled).toBe(false)
+    expect(
+      realAuthModule.auth.options.advanced?.ipAddress?.disableIpTracking,
+    ).toBe(true)
   })
 
   it('uses an isolated JWKS adapter in the test environment', () => {

--- a/apps/api/src/lib/auth/index.ts
+++ b/apps/api/src/lib/auth/index.ts
@@ -366,6 +366,14 @@ export const auth = betterAuth({
   // and then be rejected by better-auth.
   trustedOrigins: webOrigins,
 
+  // Better Auth's built-in limiter is keyed by client IP. Without a trusted
+  // proxy there is no safe per-client IP identity, so enabling it would put
+  // every caller into one replica-wide bucket. The recipient-based email
+  // limiter above remains active in either mode.
+  rateLimit: {
+    enabled: env.TRUST_PROXY,
+  },
+
   database: prismaAdapter(prisma, {
     provider: 'postgresql',
   }),
@@ -664,6 +672,7 @@ export const auth = betterAuth({
       secure: process.env.NODE_ENV === 'production',
     },
     ipAddress: {
+      disableIpTracking: !env.TRUST_PROXY,
       // The public deployment is origin-locked behind Cloudflare. Prefer its
       // single-value client header, with conventional proxy headers retained
       // for supported self-hosted gateways. The Hono adapter strips all three

--- a/apps/api/src/lib/auth/index.ts
+++ b/apps/api/src/lib/auth/index.ts
@@ -45,14 +45,6 @@ const authEmailRecipientLimiter = new FixedWindowLimiter({
   windowMs: 60 * 60 * 1000,
 })
 
-const authEmailPaths = new Map<string, 'email' | 'newEmail'>([
-  ['/sign-up/email', 'email'],
-  ['/sign-in/magic-link', 'email'],
-  ['/request-password-reset', 'email'],
-  ['/send-verification-email', 'email'],
-  ['/change-email', 'newEmail'],
-])
-
 const authMethodLabels: Record<string, string> = {
   credential: 'email and password',
   google: 'Google',
@@ -102,33 +94,32 @@ const beforeAuthMiddleware = createAuthMiddleware(async (ctx) => {
     })
   }
 
-  const emailField = authEmailPaths.get(ctx.path)
-  const rawEmail = emailField ? ctx.body?.[emailField] : undefined
-  if (typeof rawEmail === 'string') {
-    const normalizedEmail = rawEmail.trim().toLowerCase()
-    const key = hashRateLimitIdentity(normalizedEmail)
-    const decision = authEmailRecipientLimiter.hit(key)
-    if (!decision.allowed) {
-      logRateLimitExceeded({
-        policy: 'auth-email-recipient',
-        identity: normalizedEmail,
-        retryAfterSeconds: decision.retryAfterSeconds,
-        path: ctx.path,
-      })
-      throw new APIError(
-        'TOO_MANY_REQUESTS',
-        {
-          message: 'Too many email requests. Please try again later.',
-          code: 'EMAIL_RATE_LIMIT_EXCEEDED',
-        },
-        { 'Retry-After': String(decision.retryAfterSeconds) },
-      )
-    }
-  }
-
   await persistSignupInviteCookie(ctx)
   await enforceSignupGate(ctx)
 })
+
+function enforceAuthEmailRecipientLimit(email: string, path: string): void {
+  const normalizedEmail = email.trim().toLowerCase()
+  const decision = authEmailRecipientLimiter.hit(
+    hashRateLimitIdentity(normalizedEmail),
+  )
+  if (decision.allowed) return
+
+  logRateLimitExceeded({
+    policy: 'auth-email-recipient',
+    identity: normalizedEmail,
+    retryAfterSeconds: decision.retryAfterSeconds,
+    path,
+  })
+  throw new APIError(
+    'TOO_MANY_REQUESTS',
+    {
+      message: 'Too many email requests. Please try again later.',
+      code: 'EMAIL_RATE_LIMIT_EXCEEDED',
+    },
+    { 'Retry-After': String(decision.retryAfterSeconds) },
+  )
+}
 
 // Integration and unit tests share the local PostgreSQL database with the
 // already-running development API. Persisting test signing keys there would
@@ -469,6 +460,7 @@ export const auth = betterAuth({
     // outlived the user noticing the breach, the reset kicks it out.
     revokeSessionsOnPasswordReset: true,
     async sendResetPassword({ user, url }) {
+      enforceAuthEmailRecipientLimit(user.email, '/request-password-reset')
       // Best-effort: a failed send must not break the forgot-password flow.
       // better-auth already created the verification token in the DB, so the
       // user can retry from the forgot-password page and a fresh token will
@@ -498,6 +490,7 @@ export const auth = betterAuth({
     // redirecting back to the web app.
     autoSignInAfterVerification: true,
     async sendVerificationEmail({ user, url }) {
+      enforceAuthEmailRecipientLimit(user.email, '/send-verification-email')
       // Best-effort: a failed send must not break the sign-up flow.
       // better-auth already created the verification token in the DB, so the
       // user can retry from the sign-in page and a fresh token will be issued.
@@ -622,6 +615,7 @@ export const auth = betterAuth({
     magicLink({
       disableSignUp: false,
       sendMagicLink: async ({ email, url }) => {
+        enforceAuthEmailRecipientLimit(email, '/sign-in/magic-link')
         // Best-effort: a failed send must not break the magic-link sign-in
         // flow. better-auth already created the verification token in the DB,
         // so the user can retry from the sign-in page and a fresh token will

--- a/apps/api/src/lib/auth/index.ts
+++ b/apps/api/src/lib/auth/index.ts
@@ -25,6 +25,11 @@ import {
   renderPasswordRecoveryEmail,
   renderVerificationEmail,
 } from '../mail/templates'
+import {
+  FixedWindowLimiter,
+  hashRateLimitIdentity,
+  logRateLimitExceeded,
+} from '../rate-limit'
 import { invalidateAccountCache } from './account-cache'
 import {
   assertCanCreateAccount,
@@ -34,6 +39,19 @@ import {
 import { getApiBaseUrl } from './urls'
 
 const oidcProvider = getConfiguredOidcProvider()
+
+const authEmailRecipientLimiter = new FixedWindowLimiter({
+  limit: 10,
+  windowMs: 60 * 60 * 1000,
+})
+
+const authEmailPaths = new Map<string, 'email' | 'newEmail'>([
+  ['/sign-up/email', 'email'],
+  ['/sign-in/magic-link', 'email'],
+  ['/request-password-reset', 'email'],
+  ['/send-verification-email', 'email'],
+  ['/change-email', 'newEmail'],
+])
 
 const authMethodLabels: Record<string, string> = {
   credential: 'email and password',
@@ -82,6 +100,30 @@ const beforeAuthMiddleware = createAuthMiddleware(async (ctx) => {
         'Password must be at least 8 characters and include uppercase, lowercase, number, and symbol.',
       code: 'PASSWORD_POLICY_NOT_MET',
     })
+  }
+
+  const emailField = authEmailPaths.get(ctx.path)
+  const rawEmail = emailField ? ctx.body?.[emailField] : undefined
+  if (typeof rawEmail === 'string') {
+    const normalizedEmail = rawEmail.trim().toLowerCase()
+    const key = hashRateLimitIdentity(normalizedEmail)
+    const decision = authEmailRecipientLimiter.hit(key)
+    if (!decision.allowed) {
+      logRateLimitExceeded({
+        policy: 'auth-email-recipient',
+        identity: normalizedEmail,
+        retryAfterSeconds: decision.retryAfterSeconds,
+        path: ctx.path,
+      })
+      throw new APIError(
+        'TOO_MANY_REQUESTS',
+        {
+          message: 'Too many email requests. Please try again later.',
+          code: 'EMAIL_RATE_LIMIT_EXCEEDED',
+        },
+        { 'Retry-After': String(decision.retryAfterSeconds) },
+      )
+    }
   }
 
   await persistSignupInviteCookie(ctx)
@@ -620,6 +662,13 @@ export const auth = betterAuth({
       httpOnly: true,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
+    },
+    ipAddress: {
+      // The public deployment is origin-locked behind Cloudflare. Prefer its
+      // single-value client header, with conventional proxy headers retained
+      // for supported self-hosted gateways. The Hono adapter strips all three
+      // before calling Better Auth when TRUST_PROXY is disabled.
+      ipAddressHeaders: ['cf-connecting-ip', 'x-real-ip', 'x-forwarded-for'],
     },
   },
 })

--- a/apps/api/src/lib/invitations/email-invitations.ts
+++ b/apps/api/src/lib/invitations/email-invitations.ts
@@ -25,6 +25,7 @@ import { randomId } from '../api/shared'
 import { removeParticipantFromSubgroup } from '../api/subgroups'
 import { sendEmail } from '../mail/send'
 import { renderInvitationEmail } from '../mail/templates/invitation'
+import { allowUserGeneratedEmail } from '../outbound-email-rate-limit'
 import { getInvitationDisplayName } from './display'
 import {
   materializePendingInvitationParticipant,
@@ -492,6 +493,7 @@ export async function sendInvitationEmail(opts: {
   inviterDisplayName: string
   inviterRole: GroupRole
   recipientEmail: string
+  senderAccountId: string
   recipientIsExistingUser: boolean
   temporaryName?: string | null
   sourceProvider?: string
@@ -500,6 +502,15 @@ export async function sendInvitationEmail(opts: {
   totalAmount?: number
   currencyCode?: string | null
 }) {
+  if (
+    !allowUserGeneratedEmail({
+      senderAccountId: opts.senderAccountId,
+      recipientEmail: opts.recipientEmail,
+      policy: 'invitation-email',
+    })
+  )
+    return
+
   try {
     const rendered = await renderInvitationEmail(opts)
     await sendEmail({ to: opts.recipientEmail, ...rendered })

--- a/apps/api/src/lib/invitations/manage-invitations.ts
+++ b/apps/api/src/lib/invitations/manage-invitations.ts
@@ -278,6 +278,7 @@ export async function updatePendingInvitation(
       inviterDisplayName: opts.inviterDisplayName,
       inviterRole: opts.inviterRole,
       recipientEmail: updated.email,
+      senderAccountId: opts.actorAccountId,
       recipientIsExistingUser: matchedAccount !== null,
       temporaryName: matchedAccount ? undefined : updated.temporaryName,
     })

--- a/apps/api/src/lib/notifications/delivery-senders.test.ts
+++ b/apps/api/src/lib/notifications/delivery-senders.test.ts
@@ -17,12 +17,16 @@ import { EmailDeliverySenderImpl } from './email-delivery-sender'
 import { PushDeliverySenderImpl } from './push-delivery-sender'
 
 const sendPushMock = vi.hoisted(() => vi.fn(async () => undefined))
+const allowUserGeneratedEmailMock = vi.hoisted(() => vi.fn(() => true))
 vi.mock('./push', () => ({
   sendPushNotification: sendPushMock,
   isPermanentPushError: (error: unknown) => {
     const statusCode = (error as { statusCode?: number } | null)?.statusCode
     return statusCode === 404 || statusCode === 410
   },
+}))
+vi.mock('../outbound-email-rate-limit', () => ({
+  allowUserGeneratedEmail: allowUserGeneratedEmailMock,
 }))
 
 const buildEmailUnsubscribeMetadataMock = vi.hoisted(() =>
@@ -104,6 +108,8 @@ beforeEach(() => {
   sendPushMock.mockClear()
   buildEmailUnsubscribeMetadataMock.mockReset()
   buildEmailUnsubscribeMetadataMock.mockResolvedValue(null)
+  allowUserGeneratedEmailMock.mockReset()
+  allowUserGeneratedEmailMock.mockReturnValue(true)
 })
 
 describe('EmailDeliverySenderImpl', () => {
@@ -131,6 +137,7 @@ describe('EmailDeliverySenderImpl', () => {
     expect(message.html).toContain('Dinner')
     expect(message.headers?.['Message-ID']).toBe('<delivery-1@spliit.app>')
     expect(buildEmailUnsubscribeMetadataMock).not.toHaveBeenCalled()
+    expect(allowUserGeneratedEmailMock).not.toHaveBeenCalled()
     expect(message.headers?.['List-Unsubscribe']).toBeUndefined()
   })
 
@@ -201,6 +208,47 @@ describe('EmailDeliverySenderImpl', () => {
     })
     expect(sendEmailMock).not.toHaveBeenCalled()
   })
+
+  it.each([
+    ['invitation', NotificationCategory.GROUP_INVITE_RECEIVED],
+    ['friend_added', NotificationCategory.FRIEND_ADDED],
+  ] as const)(
+    'enforces user-generated quotas for %s planner emails',
+    async (kind, category) => {
+      prismaMock.account.findUnique.mockResolvedValue({
+        email: 'bob@example.com',
+        emailVerified: true,
+      } as never)
+      allowUserGeneratedEmailMock.mockReturnValue(false)
+      const snapshot = deliverySnapshotV1Schema.parse({
+        version: 1,
+        kind,
+        category,
+        occurredAt: '2026-07-02T12:00:00Z',
+        actor: { id: 'acct-alice', name: 'Alice' },
+        recipient: { accountId: 'acct-bob', displayName: 'Bob' },
+        group: { id: 'grp-1', name: 'Trip' },
+        link: 'http://localhost:3000/groups/grp-1',
+        ...(kind === 'invitation'
+          ? { inviterName: 'Alice', inviterRole: 'ADMIN' }
+          : { friendName: 'Alice' }),
+      })
+
+      await emailSender.send({
+        deliveryId: `delivery-${kind}`,
+        snapshot,
+        recipientAccountId: 'acct-bob',
+      })
+
+      expect(allowUserGeneratedEmailMock).toHaveBeenCalledWith({
+        senderAccountId: 'acct-alice',
+        recipientEmail: 'bob@example.com',
+        policy:
+          kind === 'invitation' ? 'invitation-email' : 'friend-ledger-email',
+      })
+      expect(sendEmailMock).not.toHaveBeenCalled()
+    },
+  )
 
   it('adds RFC 8058 headers and footer when the snapshot opts in to unsubscribe', async () => {
     prismaMock.account.findUnique.mockResolvedValue({

--- a/apps/api/src/lib/notifications/email-delivery-sender.ts
+++ b/apps/api/src/lib/notifications/email-delivery-sender.ts
@@ -8,6 +8,7 @@ import { renderBudgetAlertEmail } from '../mail/templates/budget-alert'
 import { renderExpenseActivityEmail } from '../mail/templates/expense-activity'
 import { renderFriendLedgerEmail } from '../mail/templates/friend-ledger'
 import { renderGroupActivityEmail } from '../mail/templates/group-activity'
+import { allowUserGeneratedEmail } from '../outbound-email-rate-limit'
 import {
   PermanentDeliveryError,
   TransientDeliveryError,
@@ -450,6 +451,31 @@ export class EmailDeliverySenderImpl implements EmailDeliverySender {
         'Recipient email is a placeholder',
         'TARGET_GONE',
       )
+    }
+
+    if (
+      args.snapshot.kind === 'invitation' ||
+      args.snapshot.kind === 'friend_added'
+    ) {
+      const senderAccountId = args.snapshot.actor?.id
+      if (!senderAccountId) {
+        throw new PermanentDeliveryError(
+          'User-generated email is missing its sender',
+          'DATA_CONTRACT',
+        )
+      }
+      if (
+        !allowUserGeneratedEmail({
+          senderAccountId,
+          recipientEmail: account.email,
+          policy:
+            args.snapshot.kind === 'invitation'
+              ? 'invitation-email'
+              : 'friend-ledger-email',
+        })
+      ) {
+        return
+      }
     }
 
     let unsubscribeUrl: string | undefined

--- a/apps/api/src/lib/outbound-email-rate-limit.test.ts
+++ b/apps/api/src/lib/outbound-email-rate-limit.test.ts
@@ -16,4 +16,39 @@ describe('user-generated email limits', () => {
     }
     expect(allowUserGeneratedEmail(options)).toBe(false)
   })
+
+  it('does not consume recipient quota after the sender is over quota', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const exhaustedSender = 'sender-dual-hit-test'
+
+    for (let count = 0; count < 200; count += 1) {
+      expect(
+        allowUserGeneratedEmail({
+          senderAccountId: exhaustedSender,
+          recipientEmail: `recipient-${count}@example.test`,
+          policy: 'test-email',
+        }),
+      ).toBe(true)
+    }
+
+    for (let count = 0; count < 10; count += 1) {
+      expect(
+        allowUserGeneratedEmail({
+          senderAccountId: exhaustedSender,
+          recipientEmail: 'protected-recipient@example.test',
+          policy: 'test-email',
+        }),
+      ).toBe(false)
+    }
+
+    for (let count = 0; count < 10; count += 1) {
+      expect(
+        allowUserGeneratedEmail({
+          senderAccountId: 'fresh-sender-dual-hit-test',
+          recipientEmail: 'protected-recipient@example.test',
+          policy: 'test-email',
+        }),
+      ).toBe(true)
+    }
+  })
 })

--- a/apps/api/src/lib/outbound-email-rate-limit.test.ts
+++ b/apps/api/src/lib/outbound-email-rate-limit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { allowUserGeneratedEmail } from './outbound-email-rate-limit'
+
+describe('user-generated email limits', () => {
+  it('suppresses repeated delivery to one recipient after the daily quota', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const options = {
+      senderAccountId: 'sender-recipient-limit-test',
+      recipientEmail: 'recipient-limit@example.test',
+      policy: 'test-email',
+    }
+
+    for (let count = 0; count < 10; count += 1) {
+      expect(allowUserGeneratedEmail(options)).toBe(true)
+    }
+    expect(allowUserGeneratedEmail(options)).toBe(false)
+  })
+})

--- a/apps/api/src/lib/outbound-email-rate-limit.ts
+++ b/apps/api/src/lib/outbound-email-rate-limit.ts
@@ -1,0 +1,43 @@
+import {
+  FixedWindowLimiter,
+  hashRateLimitIdentity,
+  logRateLimitExceeded,
+} from './rate-limit'
+
+const senderLimiter = new FixedWindowLimiter({
+  limit: 200,
+  windowMs: 24 * 60 * 60 * 1000,
+})
+const recipientLimiter = new FixedWindowLimiter({
+  limit: 10,
+  windowMs: 24 * 60 * 60 * 1000,
+})
+
+/**
+ * Best-effort daily brake for emails initiated directly by another user.
+ * Callers intentionally suppress delivery on rejection while preserving the
+ * underlying invitation/friend-ledger mutation.
+ */
+export function allowUserGeneratedEmail(options: {
+  senderAccountId: string
+  recipientEmail: string
+  policy: string
+}): boolean {
+  const senderDecision = senderLimiter.hit(options.senderAccountId)
+  const normalizedRecipient = options.recipientEmail.trim().toLowerCase()
+  const recipientDecision = recipientLimiter.hit(
+    hashRateLimitIdentity(normalizedRecipient),
+  )
+  if (senderDecision.allowed && recipientDecision.allowed) return true
+
+  const limitedByRecipient = senderDecision.allowed
+  const decision = limitedByRecipient ? recipientDecision : senderDecision
+  logRateLimitExceeded({
+    policy: `${options.policy}-${limitedByRecipient ? 'recipient' : 'sender'}`,
+    identity: limitedByRecipient
+      ? normalizedRecipient
+      : options.senderAccountId,
+    retryAfterSeconds: decision.retryAfterSeconds,
+  })
+  return false
+}

--- a/apps/api/src/lib/outbound-email-rate-limit.ts
+++ b/apps/api/src/lib/outbound-email-rate-limit.ts
@@ -24,20 +24,25 @@ export function allowUserGeneratedEmail(options: {
   policy: string
 }): boolean {
   const senderDecision = senderLimiter.hit(options.senderAccountId)
+  if (!senderDecision.allowed) {
+    logRateLimitExceeded({
+      policy: `${options.policy}-sender`,
+      identity: options.senderAccountId,
+      retryAfterSeconds: senderDecision.retryAfterSeconds,
+    })
+    return false
+  }
+
   const normalizedRecipient = options.recipientEmail.trim().toLowerCase()
   const recipientDecision = recipientLimiter.hit(
     hashRateLimitIdentity(normalizedRecipient),
   )
-  if (senderDecision.allowed && recipientDecision.allowed) return true
+  if (recipientDecision.allowed) return true
 
-  const limitedByRecipient = senderDecision.allowed
-  const decision = limitedByRecipient ? recipientDecision : senderDecision
   logRateLimitExceeded({
-    policy: `${options.policy}-${limitedByRecipient ? 'recipient' : 'sender'}`,
-    identity: limitedByRecipient
-      ? normalizedRecipient
-      : options.senderAccountId,
-    retryAfterSeconds: decision.retryAfterSeconds,
+    policy: `${options.policy}-recipient`,
+    identity: normalizedRecipient,
+    retryAfterSeconds: recipientDecision.retryAfterSeconds,
   })
   return false
 }

--- a/apps/api/src/lib/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit.test.ts
@@ -35,6 +35,21 @@ describe('FixedWindowLimiter', () => {
     expect(limiter.hit('b', now).allowed).toBe(false)
   })
 
+  it('supports weighted consumption', () => {
+    const limiter = new FixedWindowLimiter({ limit: 5, windowMs: 60_000 })
+    const now = 1_000_000
+
+    expect(limiter.hit('sender', now, 4).allowed).toBe(true)
+    expect(limiter.hit('sender', now).allowed).toBe(true)
+    expect(limiter.hit('sender', now).allowed).toBe(false)
+  })
+
+  it('rejects invalid consumption costs', () => {
+    const limiter = new FixedWindowLimiter({ limit: 5, windowMs: 60_000 })
+
+    expect(() => limiter.hit('sender', Date.now(), 0)).toThrow(RangeError)
+  })
+
   it('resets the window once it expires', () => {
     const limiter = new FixedWindowLimiter({ limit: 1, windowMs: 60_000 })
     const now = 1_000_000
@@ -72,19 +87,40 @@ describe('resolveClientIp', () => {
     expect(resolveClientIp(new Headers(), { trustProxy: false })).toBe('direct')
   })
 
-  it('uses the right-most forwarded hop when trusting the proxy', () => {
+  it('prefers Cloudflare client IP over generic proxy headers', () => {
     const headers = new Headers({
+      'cf-connecting-ip': '203.0.113.7',
       'x-forwarded-for': 'spoofed-by-client, 10.0.0.1',
+      'x-real-ip': '10.0.0.2',
     })
-    expect(resolveClientIp(headers, { trustProxy: true })).toBe('10.0.0.1')
+    expect(resolveClientIp(headers, { trustProxy: true })).toBe('203.0.113.7')
   })
 
-  it('falls back to x-real-ip then unknown when trusting the proxy', () => {
+  it('falls back to x-real-ip and then the right-most forwarded hop', () => {
     expect(
       resolveClientIp(new Headers({ 'x-real-ip': '9.9.9.9' }), {
         trustProxy: true,
       }),
     ).toBe('9.9.9.9')
+    expect(
+      resolveClientIp(
+        new Headers({ 'x-forwarded-for': '192.0.2.1, 10.0.0.1' }),
+        { trustProxy: true },
+      ),
+    ).toBe('10.0.0.1')
+  })
+
+  it('rejects malformed proxy headers', () => {
+    expect(
+      resolveClientIp(
+        new Headers({
+          'cf-connecting-ip': 'not-an-ip',
+          'x-real-ip': 'also-invalid',
+          'x-forwarded-for': 'spoofed-by-client',
+        }),
+        { trustProxy: true },
+      ),
+    ).toBe('unknown')
     expect(resolveClientIp(new Headers(), { trustProxy: true })).toBe('unknown')
   })
 })

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto'
+import { isIP } from 'node:net'
+
 type Bucket = { count: number; resetAt: number }
 
 export type RateLimitDecision = {
@@ -24,14 +27,21 @@ export class FixedWindowLimiter {
     },
   ) {}
 
-  hit(key: string, now: number = Date.now()): RateLimitDecision {
+  hit(
+    key: string,
+    now: number = Date.now(),
+    cost: number = 1,
+  ): RateLimitDecision {
+    if (!Number.isSafeInteger(cost) || cost <= 0) {
+      throw new RangeError('Rate-limit cost must be a positive safe integer')
+    }
     this.evict(now)
     const existing = this.buckets.get(key)
     const bucket: Bucket =
       !existing || existing.resetAt <= now
         ? { count: 0, resetAt: now + this.options.windowMs }
         : existing
-    bucket.count += 1
+    bucket.count += cost
     this.buckets.set(key, bucket)
     if (bucket.count > this.options.limit) {
       return {
@@ -68,23 +78,56 @@ export class FixedWindowLimiter {
  * Resolve a rate-limit identity from request headers. Forwarded headers are
  * only honored when the API is known to sit behind a trusted proxy; otherwise
  * they are client-controlled and spoofable, so every caller shares a single
- * conservative bucket. When trusted, the right-most `x-forwarded-for` hop is
- * used because the closest proxy appends (or overwrites with) the real client
- * address, while earlier entries can be forged by the client.
+ * conservative bucket. Cloudflare's single-value client header is preferred;
+ * generic proxy headers are compatibility fallbacks for self-hosted installs.
  */
 export function resolveClientIp(
   headers: Headers,
   options: { trustProxy: boolean },
 ): string {
   if (!options.trustProxy) return 'direct'
+
+  const cloudflareIp = normalizeIpHeader(headers.get('cf-connecting-ip'))
+  if (cloudflareIp) return cloudflareIp
+
+  const realIp = normalizeIpHeader(headers.get('x-real-ip'))
+  if (realIp) return realIp
+
   const forwarded = headers.get('x-forwarded-for')
   if (forwarded) {
     const hops = forwarded
       .split(',')
       .map((hop) => hop.trim())
       .filter(Boolean)
-    const ip = hops[hops.length - 1]
+    const ip = normalizeIpHeader(hops[hops.length - 1] ?? null)
     if (ip) return ip
   }
-  return headers.get('x-real-ip') ?? 'unknown'
+  return 'unknown'
+}
+
+function normalizeIpHeader(value: string | null): string | null {
+  const candidate = value?.trim()
+  if (!candidate || isIP(candidate) === 0) return null
+  return candidate.toLowerCase()
+}
+
+/** Keep abuse logs correlatable without recording raw accounts, IPs or emails. */
+export function hashRateLimitIdentity(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16)
+}
+
+export function logRateLimitExceeded(options: {
+  policy: string
+  identity: string
+  retryAfterSeconds: number
+  path?: string
+}) {
+  console.warn(
+    `[rate-limit] ${JSON.stringify({
+      policy: options.policy,
+      actorHash: hashRateLimitIdentity(options.identity),
+      retryAfterSeconds: options.retryAfterSeconds,
+      ...(options.path ? { path: options.path } : {}),
+    })}`,
+  )
 }

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -1,5 +1,9 @@
-import { createHash } from 'node:crypto'
+import { createHmac, randomBytes } from 'node:crypto'
 import { isIP } from 'node:net'
+
+import { env } from './env'
+
+const rateLimitHashSecret = env.BETTER_AUTH_SECRET ?? randomBytes(32)
 
 type Bucket = { count: number; resetAt: number }
 
@@ -113,7 +117,10 @@ function normalizeIpHeader(value: string | null): string | null {
 
 /** Keep abuse logs correlatable without recording raw accounts, IPs or emails. */
 export function hashRateLimitIdentity(value: string): string {
-  return createHash('sha256').update(value).digest('hex').slice(0, 16)
+  return createHmac('sha256', rateLimitHashSecret)
+    .update(value)
+    .digest('hex')
+    .slice(0, 16)
 }
 
 export function logRateLimitExceeded(options: {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,10 +3,13 @@ import { stopApiBoss } from './lib/api/boss'
 import { env } from './lib/env'
 import { runShutdown } from './lib/lifecycle/shutdown'
 
+const MAX_REQUEST_BODY_SIZE = 10 * 1024 * 1024
+
 const server = Bun.serve({
   fetch: app.fetch,
   port: env.PORT,
   hostname: '0.0.0.0',
+  maxRequestBodySize: MAX_REQUEST_BODY_SIZE,
 })
 console.log(`Spliit Cloud API listening on http://localhost:${env.PORT}`)
 

--- a/apps/api/src/trpc/init.test.ts
+++ b/apps/api/src/trpc/init.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '../test/mocks'
 import { clearAccountCache } from '../lib/auth/account-cache'
@@ -112,6 +112,45 @@ describe('protectedProcedure', () => {
         } as never,
       }),
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+  })
+
+  it('limits authenticated mutations per account and returns Retry-After', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const resHeaders = new Headers()
+    const mutation = protectedProcedure.mutation(() => 'ok')
+    const ctx = {
+      auth: {
+        session: { id: 'mutation-limit-session' },
+        user: {
+          id: 'mutation-limit-account',
+          email: 'mutation-limit@example.test',
+          emailVerified: true,
+          name: 'Mutation Limit',
+        },
+      },
+      resHeaders,
+    }
+    const callMutation = () =>
+      mutation({
+        ctx,
+        type: 'mutation',
+        path: 'mutationProbe',
+        getRawInput: async () => undefined,
+        meta: undefined,
+        signal: undefined,
+      } as never)
+
+    for (let count = 0; count < 120; count += 1) {
+      await expect(callMutation()).resolves.toBe('ok')
+    }
+    await expect(callMutation()).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    })
+
+    expect(Number(resHeaders.get('Retry-After'))).toBeGreaterThan(0)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('authenticated-mutation'),
+    )
   })
 })
 

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -58,29 +58,52 @@ const assistantRequestLimiter = new FixedWindowLimiter({
   limit: 120,
   windowMs: 60_000,
 })
+const authenticatedMutationLimiter = new FixedWindowLimiter({
+  limit: 120,
+  windowMs: 60_000,
+})
 
 /**
  * Procedure that requires an authenticated account. The account is exposed to
  * the procedure via `ctx.auth.user`.
  */
-export const protectedProcedure = baseProcedure.use(async ({ ctx, next }) => {
-  if (
-    !ctx.auth ||
-    ('credentialKind' in ctx.auth && ctx.auth.credentialKind === 'oauth')
-  ) {
-    throw new TRPCError({
-      code: 'UNAUTHORIZED',
-      message: 'Authentication required',
+export const protectedProcedure = baseProcedure.use(
+  async ({ ctx, next, path, type }) => {
+    if (
+      !ctx.auth ||
+      ('credentialKind' in ctx.auth && ctx.auth.credentialKind === 'oauth')
+    ) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      })
+    }
+    if (type === 'mutation') {
+      const decision = authenticatedMutationLimiter.hit(ctx.auth.user.id)
+      if (!decision.allowed) {
+        logRateLimitExceeded({
+          policy: 'authenticated-mutation',
+          identity: ctx.auth.user.id,
+          retryAfterSeconds: decision.retryAfterSeconds,
+          path,
+        })
+        ctx.resHeaders?.set('Retry-After', String(decision.retryAfterSeconds))
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Request limit exceeded; try again shortly',
+        })
+      }
+    }
+
+    return next({
+      ctx: {
+        ...ctx,
+        // Narrow the type so procedures can rely on a non-null auth.
+        auth: ctx.auth,
+      },
     })
-  }
-  return next({
-    ctx: {
-      ...ctx,
-      // Narrow the type so procedures can rely on a non-null auth.
-      auth: ctx.auth,
-    },
-  })
-})
+  },
+)
 
 function accountRateLimitedProcedure(options: {
   policy: string
@@ -122,6 +145,11 @@ const aiRequests = accountRateLimitedProcedure({
   limit: 60,
   windowMs: 60 * 60 * 1000,
 })
+const categoryAiRequests = accountRateLimitedProcedure({
+  policy: 'ai-category',
+  limit: 120,
+  windowMs: 60 * 60 * 1000,
+})
 const bulkAiRequests = accountRateLimitedProcedure({
   policy: 'ai-bulk',
   limit: 20,
@@ -138,13 +166,13 @@ const importRequests = accountRateLimitedProcedure({
   windowMs: 60 * 60 * 1000,
 })
 
-export const aiProcedure = aiRequests.procedure
-export const bulkAiProcedure = bulkAiRequests.procedure
 export const uploadPresignProcedure = uploadPresignRequests.procedure
 export const importProcedure = importRequests.procedure
 
-/** Charge only the provider fallback, leaving local category suggestions free. */
+/** Charge AI quotas only immediately before provider work. */
 export const enforceAiRequestLimit = aiRequests.enforce
+export const enforceCategoryAiRequestLimit = categoryAiRequests.enforce
+export const enforceBulkAiRequestLimit = bulkAiRequests.enforce
 
 export function assistantProcedure(requiredScope: string) {
   return baseProcedure.use(async ({ ctx, next }) => {

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -11,13 +11,15 @@ import {
 } from '../lib/auth/session'
 import { env } from '../lib/env'
 import { hashLinkToken } from '../lib/invitations'
-import { FixedWindowLimiter } from '../lib/rate-limit'
+import { FixedWindowLimiter, logRateLimitExceeded } from '../lib/rate-limit'
 
 export type AuthContext = {
   /** Authenticated account + better-auth session, or null. */
   auth: ResolvedAuth | OAuthResolvedAuth | null
   /** Outgoing fetch Request, when available (tRPC context only sees headers). */
   req?: Request
+  /** Mutable response headers supplied by the fetch adapter. */
+  resHeaders?: Headers
 }
 
 export async function createTRPCContext(opts: {
@@ -29,7 +31,7 @@ export async function createTRPCContext(opts: {
   const auth =
     (await getAuthFromRequest(request).catch(() => null)) ??
     (await getOAuthAuthFromRequest(request).catch(() => null))
-  return { auth, req: opts.req }
+  return { auth, req: opts.req, resHeaders: opts.resHeaders }
 }
 
 // Avoid exporting the entire t-object
@@ -79,6 +81,70 @@ export const protectedProcedure = baseProcedure.use(async ({ ctx, next }) => {
     },
   })
 })
+
+function accountRateLimitedProcedure(options: {
+  policy: string
+  limit: number
+  windowMs: number
+}) {
+  const limiter = new FixedWindowLimiter({
+    limit: options.limit,
+    windowMs: options.windowMs,
+  })
+
+  const enforce = (accountId: string, path?: string, resHeaders?: Headers) => {
+    const decision = limiter.hit(accountId)
+    if (decision.allowed) return
+    logRateLimitExceeded({
+      policy: options.policy,
+      identity: accountId,
+      retryAfterSeconds: decision.retryAfterSeconds,
+      path,
+    })
+    resHeaders?.set('Retry-After', String(decision.retryAfterSeconds))
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: 'Request limit exceeded; try again later',
+    })
+  }
+
+  return {
+    procedure: protectedProcedure.use(({ ctx, next, path }) => {
+      enforce(ctx.auth.user.id, path, ctx.resHeaders)
+      return next()
+    }),
+    enforce,
+  }
+}
+
+const aiRequests = accountRateLimitedProcedure({
+  policy: 'ai',
+  limit: 60,
+  windowMs: 60 * 60 * 1000,
+})
+const bulkAiRequests = accountRateLimitedProcedure({
+  policy: 'ai-bulk',
+  limit: 20,
+  windowMs: 60 * 60 * 1000,
+})
+const uploadPresignRequests = accountRateLimitedProcedure({
+  policy: 'upload-presign',
+  limit: 120,
+  windowMs: 60 * 60 * 1000,
+})
+const importRequests = accountRateLimitedProcedure({
+  policy: 'group-import',
+  limit: 20,
+  windowMs: 60 * 60 * 1000,
+})
+
+export const aiProcedure = aiRequests.procedure
+export const bulkAiProcedure = bulkAiRequests.procedure
+export const uploadPresignProcedure = uploadPresignRequests.procedure
+export const importProcedure = importRequests.procedure
+
+/** Charge only the provider fallback, leaving local category suggestions free. */
+export const enforceAiRequestLimit = aiRequests.enforce
 
 export function assistantProcedure(requiredScope: string) {
   return baseProcedure.use(async ({ ctx, next }) => {

--- a/apps/api/src/trpc/routers/ai/audio.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/audio.procedure.ts
@@ -6,7 +6,11 @@ import { prisma } from '@spliit/db'
 import { extractExpenseInformationFromAudio } from '../../../lib/audio-expense'
 import { env } from '../../../lib/env'
 import { resolveParticipantDisplayName } from '../../../lib/invitations/display'
-import { aiProcedure, loadGroupContext } from '../../init'
+import {
+  enforceAiRequestLimit,
+  loadGroupContext,
+  protectedProcedure,
+} from '../../init'
 import { extractExpenseInformationFromAudioOutputSchema } from '../../outputs/ai'
 
 const audioInputSchema = z.object({
@@ -19,7 +23,7 @@ const audioInputSchema = z.object({
   timezoneOffsetMinutes: z.number().int().min(-840).max(840).optional(),
 })
 
-export const extractExpenseInformationFromAudioProcedure = aiProcedure
+export const extractExpenseInformationFromAudioProcedure = protectedProcedure
   .input(audioInputSchema)
   .output(extractExpenseInformationFromAudioOutputSchema)
   .mutation(async ({ input, ctx }) => {
@@ -57,6 +61,12 @@ export const extractExpenseInformationFromAudioProcedure = aiProcedure
         },
       },
     })
+
+    enforceAiRequestLimit(
+      ctx.auth.user.id,
+      'ai.extractExpenseInformationFromAudio',
+      ctx.resHeaders,
+    )
 
     try {
       return await extractExpenseInformationFromAudio({

--- a/apps/api/src/trpc/routers/ai/audio.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/audio.procedure.ts
@@ -6,7 +6,7 @@ import { prisma } from '@spliit/db'
 import { extractExpenseInformationFromAudio } from '../../../lib/audio-expense'
 import { env } from '../../../lib/env'
 import { resolveParticipantDisplayName } from '../../../lib/invitations/display'
-import { loadGroupContext, protectedProcedure } from '../../init'
+import { aiProcedure, loadGroupContext } from '../../init'
 import { extractExpenseInformationFromAudioOutputSchema } from '../../outputs/ai'
 
 const audioInputSchema = z.object({
@@ -19,7 +19,7 @@ const audioInputSchema = z.object({
   timezoneOffsetMinutes: z.number().int().min(-840).max(840).optional(),
 })
 
-export const extractExpenseInformationFromAudioProcedure = protectedProcedure
+export const extractExpenseInformationFromAudioProcedure = aiProcedure
   .input(audioInputSchema)
   .output(extractExpenseInformationFromAudioOutputSchema)
   .mutation(async ({ input, ctx }) => {

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
@@ -18,7 +18,7 @@ import {
   type BulkCategorizeCandidateRow,
 } from '../../../../lib/api/category-bulk'
 import { env } from '../../../../lib/env'
-import { loadGroupContext, protectedProcedure } from '../../../init'
+import { bulkAiProcedure, loadGroupContext } from '../../../init'
 import { calibrateBulkCategorizeOutputSchema } from '../../../outputs/ai'
 
 const calibrateInputSchema = z.object({
@@ -59,10 +59,16 @@ const calibrateInputSchema = z.object({
     ),
 })
 
-export const aiBulkCategorizeCalibrateProcedure = protectedProcedure
+export const aiBulkCategorizeCalibrateProcedure = bulkAiProcedure
   .input(calibrateInputSchema)
   .output(calibrateBulkCategorizeOutputSchema)
   .mutation(async ({ ctx, input }) => {
+    if (!env.PUBLIC_ENABLE_BULK_CATEGORIZE) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Bulk categorization is disabled',
+      })
+    }
     const { member, group } = await loadGroupContext({
       groupId: input.groupId,
       accountId: ctx.auth.user.id,

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
@@ -18,7 +18,11 @@ import {
   type BulkCategorizeCandidateRow,
 } from '../../../../lib/api/category-bulk'
 import { env } from '../../../../lib/env'
-import { bulkAiProcedure, loadGroupContext } from '../../../init'
+import {
+  enforceBulkAiRequestLimit,
+  loadGroupContext,
+  protectedProcedure,
+} from '../../../init'
 import { calibrateBulkCategorizeOutputSchema } from '../../../outputs/ai'
 
 const calibrateInputSchema = z.object({
@@ -59,7 +63,7 @@ const calibrateInputSchema = z.object({
     ),
 })
 
-export const aiBulkCategorizeCalibrateProcedure = bulkAiProcedure
+export const aiBulkCategorizeCalibrateProcedure = protectedProcedure
   .input(calibrateInputSchema)
   .output(calibrateBulkCategorizeOutputSchema)
   .mutation(async ({ ctx, input }) => {
@@ -135,6 +139,11 @@ export const aiBulkCategorizeCalibrateProcedure = bulkAiProcedure
       round: input.round,
     })
 
+    enforceBulkAiRequestLimit(
+      ctx.auth.user.id,
+      'ai.bulkCategorize.calibrate',
+      ctx.resHeaders,
+    )
     const raw = await callBulkCategorizationModel({
       operation: 'bulk-calibration',
       candidateCount: candidates.length,

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
@@ -18,7 +18,11 @@ import {
   type BulkCategorizeCandidateRow,
 } from '../../../../lib/api/category-bulk'
 import { env } from '../../../../lib/env'
-import { bulkAiProcedure, loadGroupContext } from '../../../init'
+import {
+  enforceBulkAiRequestLimit,
+  loadGroupContext,
+  protectedProcedure,
+} from '../../../init'
 import { previewBulkCategorizeOutputSchema } from '../../../outputs/ai'
 
 const previewInputSchema = z.object({
@@ -48,7 +52,7 @@ const previewInputSchema = z.object({
     ),
 })
 
-export const aiBulkCategorizePreviewProcedure = bulkAiProcedure
+export const aiBulkCategorizePreviewProcedure = protectedProcedure
   .input(previewInputSchema)
   .output(previewBulkCategorizeOutputSchema)
   .mutation(async ({ ctx, input }) => {
@@ -106,6 +110,11 @@ export const aiBulkCategorizePreviewProcedure = bulkAiProcedure
     const suggestions: BulkPreviewResponse['suggestions'] = []
     const seenIds = new Set<string>()
 
+    enforceBulkAiRequestLimit(
+      ctx.auth.user.id,
+      'ai.bulkCategorize.preview',
+      ctx.resHeaders,
+    )
     for (const chunk of chunks) {
       const userContent = renderPreviewChunkPrompt({
         chunk,

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
@@ -18,7 +18,7 @@ import {
   type BulkCategorizeCandidateRow,
 } from '../../../../lib/api/category-bulk'
 import { env } from '../../../../lib/env'
-import { loadGroupContext, protectedProcedure } from '../../../init'
+import { bulkAiProcedure, loadGroupContext } from '../../../init'
 import { previewBulkCategorizeOutputSchema } from '../../../outputs/ai'
 
 const previewInputSchema = z.object({
@@ -48,10 +48,16 @@ const previewInputSchema = z.object({
     ),
 })
 
-export const aiBulkCategorizePreviewProcedure = protectedProcedure
+export const aiBulkCategorizePreviewProcedure = bulkAiProcedure
   .input(previewInputSchema)
   .output(previewBulkCategorizeOutputSchema)
   .mutation(async ({ ctx, input }) => {
+    if (!env.PUBLIC_ENABLE_BULK_CATEGORIZE) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Bulk categorization is disabled',
+      })
+    }
     const { member, group } = await loadGroupContext({
       groupId: input.groupId,
       accountId: ctx.auth.user.id,

--- a/apps/api/src/trpc/routers/ai/receipt.procedure.test.ts
+++ b/apps/api/src/trpc/routers/ai/receipt.procedure.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { aiRouter } from '.'
+
+describe('receipt extraction authorization', () => {
+  it('rejects anonymous requests before invoking receipt extraction', async () => {
+    const caller = aiRouter.createCaller({ auth: null })
+
+    await expect(
+      caller.extractExpenseInformationFromImage({
+        imageUrl: 'https://example.test/receipt.jpg',
+        currency: '$',
+        currencyCode: 'USD',
+        groupId: 'group-1',
+      }),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+  })
+
+  it('enforces the server feature flag for authenticated requests', async () => {
+    const caller = aiRouter.createCaller({
+      auth: {
+        session: { id: 'session-1' },
+        user: {
+          id: 'account-1',
+          email: 'alice@example.test',
+          emailVerified: true,
+          name: 'Alice',
+        },
+      },
+    } as never)
+
+    await expect(
+      caller.extractExpenseInformationFromImage({
+        imageUrl: 'https://example.test/receipt.jpg',
+        currency: '$',
+        currencyCode: 'USD',
+        groupId: 'group-1',
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+})

--- a/apps/api/src/trpc/routers/ai/receipt.procedure.test.ts
+++ b/apps/api/src/trpc/routers/ai/receipt.procedure.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const envState = vi.hoisted(() => ({
+  PUBLIC_ENABLE_RECEIPT_EXTRACT: false,
+}))
+
+vi.mock(import('../../../lib/env'), async (importOriginal) => {
+  const actual = await importOriginal()
+  const mockedEnv = { ...actual.env }
+  Object.defineProperty(mockedEnv, 'PUBLIC_ENABLE_RECEIPT_EXTRACT', {
+    enumerable: true,
+    get: () => envState.PUBLIC_ENABLE_RECEIPT_EXTRACT,
+  })
+  return { ...actual, env: mockedEnv }
+})
 
 import { aiRouter } from '.'
+
+beforeEach(() => {
+  envState.PUBLIC_ENABLE_RECEIPT_EXTRACT = false
+})
 
 describe('receipt extraction authorization', () => {
   it('rejects anonymous requests before invoking receipt extraction', async () => {

--- a/apps/api/src/trpc/routers/ai/receipt.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/receipt.procedure.ts
@@ -1,13 +1,15 @@
+import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 
 import { categoryIdSchema } from '@spliit/domain'
 
 import { getRecentExpenseContext } from '../../../lib/ai/context'
+import { env } from '../../../lib/env'
 import { extractExpenseInformationFromImage } from '../../../lib/receipt-actions'
-import { baseProcedure, loadGroupViewer } from '../../init'
+import { aiProcedure, loadGroupViewer } from '../../init'
 import { extractExpenseInformationOutputSchema } from '../../outputs/ai'
 
-export const extractExpenseInformationFromImageProcedure = baseProcedure
+export const extractExpenseInformationFromImageProcedure = aiProcedure
   .input(
     z.object({
       imageUrl: z.url(),
@@ -41,24 +43,19 @@ export const extractExpenseInformationFromImageProcedure = baseProcedure
   )
   .output(extractExpenseInformationOutputSchema)
   .mutation(async ({ input, ctx }) => {
-    let recentExpenses: Awaited<
-      ReturnType<typeof getRecentExpenseContext>
-    >['expenses'] = []
-    let groupContext:
-      | Awaited<ReturnType<typeof getRecentExpenseContext>>['group']
-      | undefined
-
-    if (ctx.auth) {
-      await loadGroupViewer({
-        groupId: input.groupId,
-        accountId: ctx.auth.user.id,
-        accountEmail: ctx.auth.user.email,
-        linkTokenHash: null,
+    if (!env.PUBLIC_ENABLE_RECEIPT_EXTRACT) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Receipt extraction is disabled',
       })
-      const context = await getRecentExpenseContext(input.groupId)
-      recentExpenses = context.expenses
-      groupContext = context.group
     }
+    await loadGroupViewer({
+      groupId: input.groupId,
+      accountId: ctx.auth.user.id,
+      accountEmail: ctx.auth.user.email,
+      linkTokenHash: null,
+    })
+    const context = await getRecentExpenseContext(input.groupId)
 
     const result = await extractExpenseInformationFromImage(
       input.imageUrl,
@@ -67,8 +64,8 @@ export const extractExpenseInformationFromImageProcedure = baseProcedure
         currencyCode: input.currencyCode,
       },
       {
-        recentExpenses,
-        groupContext,
+        recentExpenses: context.expenses,
+        groupContext: context.group,
         locale: input.locale,
         translateToLocale: input.translateToLocale,
         currentExpense: input.currentExpense,

--- a/apps/api/src/trpc/routers/ai/receipt.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/receipt.procedure.ts
@@ -6,10 +6,14 @@ import { categoryIdSchema } from '@spliit/domain'
 import { getRecentExpenseContext } from '../../../lib/ai/context'
 import { env } from '../../../lib/env'
 import { extractExpenseInformationFromImage } from '../../../lib/receipt-actions'
-import { aiProcedure, loadGroupViewer } from '../../init'
+import {
+  enforceAiRequestLimit,
+  loadGroupViewer,
+  protectedProcedure,
+} from '../../init'
 import { extractExpenseInformationOutputSchema } from '../../outputs/ai'
 
-export const extractExpenseInformationFromImageProcedure = aiProcedure
+export const extractExpenseInformationFromImageProcedure = protectedProcedure
   .input(
     z.object({
       imageUrl: z.url(),
@@ -56,6 +60,11 @@ export const extractExpenseInformationFromImageProcedure = aiProcedure
       linkTokenHash: null,
     })
     const context = await getRecentExpenseContext(input.groupId)
+    enforceAiRequestLimit(
+      ctx.auth.user.id,
+      'ai.extractExpenseInformationFromImage',
+      ctx.resHeaders,
+    )
 
     const result = await extractExpenseInformationFromImage(
       input.imageUrl,

--- a/apps/api/src/trpc/routers/friends/index.ts
+++ b/apps/api/src/trpc/routers/friends/index.ts
@@ -20,6 +20,7 @@ import { getPlaceholderEmailDisplayName } from '../../../lib/invitations/display
 import { sendEmail } from '../../../lib/mail/send'
 import { renderFriendLedgerEmail } from '../../../lib/mail/templates/friend-ledger'
 import { planActivityNotificationDeliveries } from '../../../lib/notifications/delivery-planner'
+import { allowUserGeneratedEmail } from '../../../lib/outbound-email-rate-limit'
 import { createTRPCRouter, protectedProcedure } from '../../init'
 
 /**
@@ -29,9 +30,19 @@ import { createTRPCRouter, protectedProcedure } from '../../init'
  */
 async function sendFriendLedgerNotification(opts: {
   recipientEmail: string
+  senderAccountId: string
   inviterName: string
   isNewUser: boolean
 }): Promise<void> {
+  if (
+    !allowUserGeneratedEmail({
+      senderAccountId: opts.senderAccountId,
+      recipientEmail: opts.recipientEmail,
+      policy: 'friend-ledger-email',
+    })
+  )
+    return
+
   try {
     const rendered = await renderFriendLedgerEmail({
       inviterName: opts.inviterName,
@@ -201,6 +212,7 @@ export const friendsRouter = createTRPCRouter({
         const isNewUser = !!result.invitationId
         await sendFriendLedgerNotification({
           recipientEmail: peer.email,
+          senderAccountId: callerId,
           inviterName,
           isNewUser,
         })

--- a/apps/api/src/trpc/routers/groups/expenses/suggest-category.procedure.ts
+++ b/apps/api/src/trpc/routers/groups/expenses/suggest-category.procedure.ts
@@ -5,7 +5,7 @@ import { categoryIdSchema } from '@spliit/domain'
 import { suggestExpenseCategory } from '../../../../lib/api/expenses/suggest-category'
 import {
   hashLinkInviteToken,
-  enforceAiRequestLimit,
+  enforceCategoryAiRequestLimit,
   linkInviteTokenInput,
   loadGroupViewer,
   protectedProcedure,
@@ -41,7 +41,7 @@ export const suggestCategoryProcedure = protectedProcedure
       locale: input.locale,
       allowAi: input.allowAi,
       beforeAi: () =>
-        enforceAiRequestLimit(
+        enforceCategoryAiRequestLimit(
           ctx.auth.user.id,
           'groups.expenses.suggestCategory',
           ctx.resHeaders,

--- a/apps/api/src/trpc/routers/groups/expenses/suggest-category.procedure.ts
+++ b/apps/api/src/trpc/routers/groups/expenses/suggest-category.procedure.ts
@@ -5,6 +5,7 @@ import { categoryIdSchema } from '@spliit/domain'
 import { suggestExpenseCategory } from '../../../../lib/api/expenses/suggest-category'
 import {
   hashLinkInviteToken,
+  enforceAiRequestLimit,
   linkInviteTokenInput,
   loadGroupViewer,
   protectedProcedure,
@@ -39,5 +40,11 @@ export const suggestCategoryProcedure = protectedProcedure
       title: input.title,
       locale: input.locale,
       allowAi: input.allowAi,
+      beforeAi: () =>
+        enforceAiRequestLimit(
+          ctx.auth.user.id,
+          'groups.expenses.suggestCategory',
+          ctx.resHeaders,
+        ),
     })
   })

--- a/apps/api/src/trpc/routers/groups/import-cloud.procedure.ts
+++ b/apps/api/src/trpc/routers/groups/import-cloud.procedure.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../lib/api/import-cloud'
 import { enqueueBudgetEvaluation } from '../../../lib/budgets/enqueue'
 import { deleteS3Object } from '../../../routes/upload'
-import { protectedProcedure } from '../../init'
+import { importProcedure } from '../../init'
 import { importCloudBundleOutputSchema } from '../../outputs/imports'
 
 const participantMappingSchema = z.discriminatedUnion('mode', [
@@ -100,7 +100,7 @@ const cloudImportInputSchema = z.object({
     .optional(),
 })
 
-export const importCloudBundleProcedure = protectedProcedure
+export const importCloudBundleProcedure = importProcedure
   .input(cloudImportInputSchema)
   .output(importCloudBundleOutputSchema)
   .mutation(async ({ input, ctx }) => {

--- a/apps/api/src/trpc/routers/groups/import.procedure.ts
+++ b/apps/api/src/trpc/routers/groups/import.procedure.ts
@@ -16,7 +16,7 @@ import { enqueueBudgetEvaluation } from '../../../lib/budgets/enqueue'
 import { ConversionError } from '../../../lib/expense-conversion'
 import { sendInvitationEmail } from '../../../lib/invitations'
 import { deleteS3Object } from '../../../routes/upload'
-import { loadGroupContext, protectedProcedure } from '../../init'
+import { importProcedure, loadGroupContext } from '../../init'
 import { importGroupOutputSchema } from '../../outputs/imports'
 
 // `sourceName` is the imported participant's display label. It is required for
@@ -100,7 +100,7 @@ export const importExpenseSchema = z.preprocess((value) => {
   }
 }, expenseApiSchema)
 
-export const importGroupProcedure = protectedProcedure
+export const importGroupProcedure = importProcedure
   .input(
     z
       .object({
@@ -234,7 +234,10 @@ export const importGroupProcedure = protectedProcedure
       if (!replayed) {
         await Promise.all(
           (result.emailDispatches ?? []).map((email) =>
-            sendInvitationEmail(email),
+            sendInvitationEmail({
+              ...email,
+              senderAccountId: ctx.auth.user.id,
+            }),
           ),
         )
       }

--- a/apps/api/src/trpc/routers/invitations/index.test.ts
+++ b/apps/api/src/trpc/routers/invitations/index.test.ts
@@ -321,6 +321,8 @@ describe('invitationsRouter.create', () => {
     } as never)
     prismaMock.groupInvitation.create.mockResolvedValue({
       id: 'inv-new',
+      email: 'bob@example.com',
+      temporaryName: null,
     } as never)
 
     const caller = makeCaller('acct-admin')
@@ -359,6 +361,8 @@ describe('invitationsRouter.create', () => {
     } as never)
     prismaMock.groupInvitation.create.mockResolvedValue({
       id: 'inv-member',
+      email: 'bob@example.com',
+      temporaryName: null,
     } as never)
 
     const caller = makeCaller('acct-member')

--- a/apps/api/src/trpc/routers/invitations/index.ts
+++ b/apps/api/src/trpc/routers/invitations/index.ts
@@ -369,6 +369,7 @@ export const invitationsRouter = createTRPCRouter({
             ctx.auth.user.email,
           inviterRole: member.role,
           recipientEmail: value.email,
+          senderAccountId: ctx.auth.user.id,
           recipientIsExistingUser: false,
           temporaryName: value.temporaryName,
         })

--- a/apps/api/src/trpc/routers/uploads/index.ts
+++ b/apps/api/src/trpc/routers/uploads/index.ts
@@ -7,7 +7,7 @@ import {
   mintImportDocumentPresign,
   mintProfileImagePresign,
 } from '../../../routes/upload'
-import { createTRPCRouter, protectedProcedure } from '../../init'
+import { createTRPCRouter, uploadPresignProcedure } from '../../init'
 import {
   profileImagePresignOutputSchema,
   importDocumentPresignOutputSchema,
@@ -50,7 +50,7 @@ const profileImageInput = z.object({
  * caller's account, so we skip the redundant cookie round-trip.
  */
 export const uploadsRouter = createTRPCRouter({
-  importDocumentPresign: protectedProcedure
+  importDocumentPresign: uploadPresignProcedure
     .input(
       z.object({
         sessionId: z.uuid(),
@@ -72,7 +72,7 @@ export const uploadsRouter = createTRPCRouter({
       )) as { uploadUrl: string; stagedToken: string }
     }),
 
-  cloudImportDocumentPresign: protectedProcedure
+  cloudImportDocumentPresign: uploadPresignProcedure
     .input(
       z.object({
         sessionId: z.uuid(),
@@ -102,7 +102,7 @@ export const uploadsRouter = createTRPCRouter({
    * directly to S3/R2, then passes the returned `fileUrl` in the expense's
    * `documents` array.
    */
-  presign: protectedProcedure
+  presign: uploadPresignProcedure
     .input(presignInput)
     .output(uploadPresignOutputSchema)
     .mutation(async ({ ctx, input }) => {
@@ -125,7 +125,7 @@ export const uploadsRouter = createTRPCRouter({
    * Get a presigned PUT URL for a profile image upload. Pass the returned
    * `fileUrl` to `account.setProfileImage`.
    */
-  profileImagePresign: protectedProcedure
+  profileImagePresign: uploadPresignProcedure
     .input(profileImageInput)
     .output(profileImagePresignOutputSchema)
     .mutation(async ({ ctx, input }) => {

--- a/compose.dokploy.yaml
+++ b/compose.dokploy.yaml
@@ -24,7 +24,7 @@ services:
     environment:
       PORT: 3001
       WEB_ORIGINS: ${WEB_ORIGINS}
-      TRUST_PROXY: ${TRUST_PROXY:-true}
+      TRUST_PROXY: ${TRUST_PROXY:-false}
       DATABASE_URL: ${DATABASE_URL}
       DATABASE_APPLICATION_NAME: spliit-api
       DATABASE_POOL_SIZE: ${DATABASE_POOL_SIZE:-10}

--- a/compose.yaml
+++ b/compose.yaml
@@ -47,7 +47,7 @@ services:
       WEB_ORIGINS: ${WEB_ORIGINS:-${APP_URL:?APP_URL must be set}}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-${APP_URL:?APP_URL must be set}}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}
-      TRUST_PROXY: ${TRUST_PROXY:-true}
+      TRUST_PROXY: ${TRUST_PROXY:-false}
       SMTP_HOST: ${SMTP_HOST:?SMTP_HOST must be set}
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}

--- a/container.env.example
+++ b/container.env.example
@@ -9,9 +9,9 @@ APP_URL=https://spliit.example.com
 # Leave both empty for the normal same-origin setup.
 WEB_ORIGINS=
 BETTER_AUTH_URL=
-# Keep true behind a trusted reverse proxy. Set false if clients can connect
-# directly to a gateway bound beyond loopback.
-TRUST_PROXY=true
+# Enable only after the origin is restricted to trusted proxy traffic. A direct
+# caller can spoof forwarded client-IP headers while the origin is public.
+TRUST_PROXY=false
 
 # PostgreSQL. Generate a long random password and back up the Docker volume.
 POSTGRES_DB=spliit

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -141,9 +141,10 @@ storage must be backed up separately when expense documents are enabled.
 - Terminate HTTPS before the web container and enable HSTS at the outer proxy.
 - Do not publish PostgreSQL or the worker health port.
 - Leave the API private unless a split-origin deployment requires it.
-- Keep `TRUST_PROXY=true` only when the gateway is reached through a trusted
-  reverse proxy. Set it to `false` if clients connect directly to a gateway
-  bound beyond loopback.
+- Keep `TRUST_PROXY=false` until the origin is restricted to trusted proxy
+  traffic. Enable it only after that restriction is active; otherwise direct
+  callers can spoof forwarded client-IP headers. For Cloudflare, apply the
+  Cloudflare-source allowlist before deploying with `TRUST_PROXY=true`.
 - Protect `container.env`, database backups, SMTP credentials, and auth secrets.
 - Configure SPF, DKIM, and DMARC for `EMAIL_FROM`.
 - Pin `SPLIIT_TAG` when you prefer scheduled upgrades over tracking `latest`.


### PR DESCRIPTION
# Simple Abuse and Overload Protection

## Summary

Add layered protection without Redis, CAPTCHA, or aggressive quotas:

1. Cloudflare blocks bursts and common automated abuse before requests reach Hetzner.
2. The VPS accepts web traffic only from Cloudflare, preventing direct-origin bypass.
3. The API applies account/action-aware limits, fixes unauthenticated AI access, caps request bodies, and uses Cloudflare’s real client IP.
4. Limits remain process-local and best-effort, appropriate for the current single API replica.

## Implementation Changes

### API safeguards

- Standardize client-IP resolution:
  - When `TRUST_PROXY=true`, prefer validated `CF-Connecting-IP`, then the trusted proxy’s single-value `X-Real-IP`, with `X-Forwarded-For` only as a compatibility fallback.
  - Configure Better Auth to use the same ordered headers.
  - Ignore forwarded headers when `TRUST_PROXY=false`.
  - Preserve IPv6 normalization and bounded limiter storage.

- Set Bun’s maximum request body size to **10 MiB**. Oversized requests return `413`; existing 1.5 MB audio, 2 MB document, and 512 KB avatar limits remain unchanged.

- Add reusable tRPC rate-limit middleware keyed by authenticated account, or trusted client IP for deliberately public/token-authorized actions:

| Action class | Quota | Coverage |
|---|---:|---|
| Authenticated mutations | 120/minute/account | Coarse protection for normal writes |
| AI category extraction | 120/hour/actor | Account or validated link-invite identity |
| Receipt/audio AI | 60/hour/account | Require authentication before provider calls |
| Bulk AI operations | 20/hour/account | Preview/calibration/provider-backed work |
| Upload presigns | 120/hour/account | Profile, receipt, and import-document presigns |
| Large/import operations | 20/hour/account | Group and cloud imports |
| Outbound invitation emails | 200/day/sender and 10/day/recipient | Charge by recipient count, including bulk imports |
| Auth emails | 10/hour/recipient | Magic links, verification, and password recovery |

- Return `TOO_MANY_REQUESTS`/HTTP `429` before database transactions, SMTP delivery, S3 presigning, or AI-provider calls. Include `Retry-After` where the response path supports headers.

- Close the current AI authorization gap:
  - Receipt and audio extraction require an authenticated account.
  - Category extraction requires either authentication or a successfully validated link-invite token.
  - Anonymous requests with neither credential are rejected before any AI call.

- Retain Better Auth’s existing production throttles rather than stacking duplicate auth-path middleware: sign-in/sign-up protections, 3 password/verification emails per minute, 5 magic-link requests per minute, and its broad burst guard.

- Add sampled abuse logging containing policy name, route, retry delay, and an opaque actor-key hash. Never log raw IPs, emails, tokens, cookies, or request bodies.

### Cloudflare Free configuration

- Keep `api.spliit.cloud` orange-cloud proxied and configure:
  - SSL/TLS mode: **Full (strict)**.
  - Minimum TLS: **1.2**.
  - Always Use HTTPS: enabled.
  - HSTS: six months, include subdomains, no preload initially.
  - Cloudflare Free Managed Ruleset: enabled.
  - Bot Fight Mode: enabled.
  - Browser Integrity Check: enabled.

- Use the single Free-plan rate-limiting rule:
  - Match dynamic API paths: `/trpc/*`, `/auth/*`, `/groups/*/export/*`, `/imports/*`, `/email/unsubscribe`, and OAuth protocol endpoints.
  - Count by client IP.
  - Threshold: **100 requests per 10 seconds**.
  - Action: **Block for 10 seconds**.
  - Exclude static Pages assets and health endpoints.
  - Cloudflare Free currently supports one IP-based, 10-second rate-limit rule; this broad circuit breaker deliberately leaves fine-grained quotas to the API. [Cloudflare rate-limiting availability](https://developers.cloudflare.com/waf/rate-limiting-rules/)

- Add one custom WAF rule for `api.spliit.cloud` that blocks methods other than `GET`, `POST`, and `OPTIONS`. Leave the remaining Free custom-rule capacity unused until Security Events show a specific pattern; Free zones support five custom WAF rules. [Cloudflare custom rules](https://developers.cloudflare.com/waf/custom-rules/)

- Do not add Turnstile yet. Introduce it later only if distributed sign-up or email abuse defeats IP/account quotas.

### Origin lock-down

- In the Hetzner firewall, allow inbound `80/443` only from Cloudflare’s published IPv4 and IPv6 ranges, then deny all other sources. Preserve SSH through the existing trusted administrator source before applying the rule.
- Ensure Dokploy/Traefik only routes the exact expected hostnames and does not expose API port `3001`, worker port `3003`, PostgreSQL, or a default catch-all virtual host.
- Maintain the Cloudflare IP allowlist when Cloudflare publishes changes. Cloudflare explicitly recommends blocking non-Cloudflare web traffic to prevent direct-origin bypass. [Cloudflare origin firewall guidance](https://developers.cloudflare.com/fundamentals/concepts/cloudflare-ip-addresses/)
- Treat Authenticated Origin Pulls as a later enhancement; the IP allowlist plus exact-host routing is the simpler first step.

## Test and Rollout Plan

- Unit-test limiter boundaries, reset timing, weighted recipient consumption, bounded memory, and independent actors.
- Test trusted-IP behavior for Cloudflare, generic proxy fallback, IPv4/IPv6, spoofed headers, and `TRUST_PROXY=false`.
- Verify every protected action allows requests through its quota, rejects the next request with `429`, and does not invoke Prisma, SMTP, S3, or AI after rejection.
- Verify unauthenticated AI requests fail and authenticated/link-authorized flows continue working.
- Test a payload just below 10 MiB succeeds and one above it returns `413`; retain the existing 1,113-expense import scenario.
- Run API unit tests, type checks, lint, and formatting checks with Bun.
- Roll out in this order:
  1. Deploy API safeguards and confirm real client-IP logging locally at the server.
  2. Enable Cloudflare security settings and the rate rule.
  3. Apply the Hetzner allowlist while retaining console/SSH recovery access.
  4. Confirm normal web, auth, OAuth/MCP, exports, uploads, and health checks.
  5. Confirm `curl --resolve api.spliit.cloud:443:<origin-ip>` from a non-Cloudflare source fails while the public hostname succeeds.
  6. Review Cloudflare Security Events and API 429 counts after 24 hours and seven days; raise quotas if legitimate traffic approaches 50% of a limit.

## Assumptions

- The Cloudflare zone is on the Free plan.
- The current production API has one replica; process-local counters resetting on restart are acceptable for this first iteration.
- Ports `80/443` on the Hetzner VPS may be restricted to Cloudflare, while administrative access remains separately allowlisted.
- No database migration, Redis service, Terraform stack, Turnstile UI, or user-facing quota settings are added in this phase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved protection against spoofed proxy headers and unauthorized client-IP information.
  * Added rate limits for authentication, exports, reports, uploads, imports, OAuth registration, and AI-powered actions.
  * Added a 10 MiB maximum request-body size.
  * Trusted proxy handling now defaults to disabled for safer deployments.

* **Bug Fixes**
  * Receipt extraction now consistently requires authentication and feature availability.
  * Rate-limited requests provide retry guidance.

* **Email**
  * Added safeguards limiting invitation, friend-notification, and authentication emails to help prevent abuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->