### PR TITLE
fix(ai): use structured outputs for bulk categorization

### DIFF
--- a/apps/api/src/lib/ai/categorize.test.ts
+++ b/apps/api/src/lib/ai/categorize.test.ts
@@ -1,12 +1,33 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
+vi.mock('ai', async () => {
+  const actual = await vi.importActual('ai')
+  return { ...actual, generateText: vi.fn() }
+})
+
+vi.mock('../ai', () => ({ getModel: vi.fn() }))
+
+const { generateText } = await import('ai')
+const { getModel } = await import('../ai')
+const {
+  BULK_CATEGORIZATION_MAX_RETRIES,
+  BULK_CATEGORIZATION_TIMEOUT_MS,
   buildCategorizationSystemPrompt,
   bulkPreviewResponseSchema,
   calibrationJsonSchema,
   calibrationResponseSchema,
+  callBulkCategorizationModel,
   parseCategoryId,
-} from './categorize'
+} = await import('./categorize')
+
+const generateTextMock = vi.mocked(generateText)
+const getModelMock = vi.mocked(getModel)
+
+beforeEach(() => {
+  generateTextMock.mockReset()
+  getModelMock.mockReset()
+  getModelMock.mockResolvedValue({ modelId: 'test-model' } as never)
+})
 
 describe('buildCategorizationSystemPrompt', () => {
   it('emits the category allowlist and fallback', () => {
@@ -127,6 +148,86 @@ describe('bulk preview schemas', () => {
         },
       ],
     })
+  })
+})
+
+describe('callBulkCategorizationModel', () => {
+  it('returns structured calibration output without reading text', async () => {
+    const output = {
+      needsFeedback: true,
+      selections: [
+        {
+          expenseId: 'expense-1',
+          suggestedCategoryId: 'groceries' as const,
+          confidence: 'high' as const,
+        },
+      ],
+    }
+    generateTextMock.mockResolvedValue({ output } as never)
+
+    await expect(
+      callBulkCategorizationModel({
+        operation: 'bulk-calibration',
+        prompt: {
+          model: 'configured-model',
+          instructions: 'Classify expenses.',
+          prompt: 'Expense candidates',
+        },
+        candidateCount: 1,
+        priorFeedbackCount: 0,
+        round: 1,
+      }),
+    ).resolves.toEqual(output)
+
+    expect(getModelMock).toHaveBeenCalledWith('configured-model')
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expect.anything(),
+        reasoning: 'none',
+        maxRetries: BULK_CATEGORIZATION_MAX_RETRIES,
+        timeout: BULK_CATEGORIZATION_TIMEOUT_MS,
+      }),
+    )
+  })
+
+  it('returns structured preview output when text is malformed', async () => {
+    const output = {
+      suggestions: [
+        {
+          expenseId: 'expense-2',
+          suggestedCategoryId: 'dining-out' as const,
+          confidence: 'medium' as const,
+        },
+      ],
+    }
+    generateTextMock.mockResolvedValue({
+      output,
+      text: 'this is not JSON',
+    } as never)
+
+    await expect(
+      callBulkCategorizationModel({
+        operation: 'bulk-preview',
+        prompt: {
+          model: 'configured-model',
+          instructions: 'Classify expenses.',
+          prompt: 'Expense candidates',
+          temperature: 0,
+        },
+        candidateCount: 1,
+        priorFeedbackCount: 0,
+      }),
+    ).resolves.toEqual(output)
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expect.anything(),
+        temperature: 0,
+        reasoning: 'none',
+        maxRetries: BULK_CATEGORIZATION_MAX_RETRIES,
+        timeout: BULK_CATEGORIZATION_TIMEOUT_MS,
+      }),
+    )
   })
 })
 

--- a/apps/api/src/lib/ai/categorize.test.ts
+++ b/apps/api/src/lib/ai/categorize.test.ts
@@ -229,6 +229,69 @@ describe('callBulkCategorizationModel', () => {
       }),
     )
   })
+
+  it('uses tolerant JSON parsing when the model lacks structured outputs', async () => {
+    getModelMock.mockResolvedValue({
+      modelId: 'compatible-model',
+      supportsStructuredOutputs: false,
+    } as never)
+    generateTextMock.mockResolvedValue({
+      output: {
+        suggestions: [
+          {
+            expenseId: 'expense-3',
+            suggestedCategoryId: 'groceries',
+            confidence: ' High ',
+          },
+        ],
+      },
+    } as never)
+
+    await expect(
+      callBulkCategorizationModel({
+        operation: 'bulk-preview',
+        prompt: {
+          model: 'compatible-model',
+          instructions: 'Classify expenses.',
+          prompt: 'Expense candidates',
+        },
+        candidateCount: 1,
+        priorFeedbackCount: 0,
+      }),
+    ).resolves.toEqual({
+      suggestions: [
+        {
+          expenseId: 'expense-3',
+          suggestedCategoryId: 'groceries',
+          confidence: 'high',
+        },
+      ],
+    })
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expect.objectContaining({ name: 'json' }),
+      }),
+    )
+  })
+
+  it('propagates provider errors', async () => {
+    const providerError = new Error('provider unavailable')
+    generateTextMock.mockRejectedValue(providerError)
+
+    await expect(
+      callBulkCategorizationModel({
+        operation: 'bulk-preview',
+        prompt: {
+          model: 'configured-model',
+          instructions: 'Classify expenses.',
+          prompt: 'Expense candidates',
+        },
+        candidateCount: 1,
+        priorFeedbackCount: 0,
+      }),
+    ).rejects.toBe(providerError)
+  })
 })
 
 describe('parseCategoryId', () => {

--- a/apps/api/src/lib/ai/categorize.ts
+++ b/apps/api/src/lib/ai/categorize.ts
@@ -1,4 +1,4 @@
-import { generateText } from 'ai'
+import { generateText, Output } from 'ai'
 import * as z from 'zod'
 
 import {
@@ -107,6 +107,12 @@ const confidenceSchema = z.preprocess(
   z.enum(['high', 'medium', 'low']),
 )
 
+// Keep the model-facing schemas free of transforms and defaults. OpenAI's
+// strict structured-output mode requires every property to be represented as
+// required in the generated JSON Schema. The public parsers below stay
+// deliberately lenient for backwards compatibility with stored/test data.
+const modelConfidenceSchema = z.enum(['high', 'medium', 'low'])
+
 export const BULK_CATEGORIZATION_TIMEOUT_MS = 245_000
 export const BULK_CATEGORIZATION_MAX_RETRIES = 0
 
@@ -207,12 +213,35 @@ export const bulkPreviewResponseSchema = z.object({
 })
 export type BulkPreviewResponse = z.infer<typeof bulkPreviewResponseSchema>
 
+const calibrationModelResponseSchema = z.object({
+  needsFeedback: z.boolean(),
+  selections: z
+    .array(
+      z.object({
+        expenseId: z.string().min(1),
+        suggestedCategoryId: categoryIdSchema,
+        confidence: modelConfidenceSchema,
+      }),
+    )
+    .max(BULK_CALIBRATION_SAMPLE_SIZE),
+})
+
+const bulkPreviewModelResponseSchema = z.object({
+  suggestions: z.array(
+    z.object({
+      expenseId: z.string().min(1),
+      suggestedCategoryId: categoryIdSchema,
+      confidence: modelConfidenceSchema,
+    }),
+  ),
+})
+
 /**
  * Shared AI call for bulk calibration and preview. Keeps the request bounded
  * with an explicit timeout and no SDK retries so a slow provider cannot hang
  * the tRPC handler.
  */
-export async function callBulkCategorizationModel(args: {
+type BulkCategorizationModelArgs = {
   operation: 'bulk-calibration' | 'bulk-preview'
   prompt: {
     model: string
@@ -223,11 +252,36 @@ export async function callBulkCategorizationModel(args: {
   candidateCount: number
   priorFeedbackCount: number
   round?: number
-}): Promise<string | null | undefined> {
+}
+
+export function callBulkCategorizationModel(
+  args: BulkCategorizationModelArgs & { operation: 'bulk-calibration' },
+): Promise<CalibrationResponse>
+export function callBulkCategorizationModel(
+  args: BulkCategorizationModelArgs & { operation: 'bulk-preview' },
+): Promise<BulkPreviewResponse>
+export async function callBulkCategorizationModel(
+  args: BulkCategorizationModelArgs,
+): Promise<CalibrationResponse | BulkPreviewResponse> {
+  const output =
+    args.operation === 'bulk-calibration'
+      ? Output.object({
+          name: 'bulk_calibration',
+          description:
+            'Representative expenses to review before bulk categorization.',
+          schema: calibrationModelResponseSchema,
+        })
+      : Output.object({
+          name: 'bulk_category_preview',
+          description: 'Category suggestions for a chunk of expenses.',
+          schema: bulkPreviewModelResponseSchema,
+        })
+
   const result = await generateText({
     model: await getModel(args.prompt.model),
     instructions: args.prompt.instructions,
     prompt: args.prompt.prompt,
+    output,
     reasoning: 'none',
     maxRetries: BULK_CATEGORIZATION_MAX_RETRIES,
     timeout: BULK_CATEGORIZATION_TIMEOUT_MS,
@@ -235,5 +289,5 @@ export async function callBulkCategorizationModel(args: {
       ? {}
       : { temperature: args.prompt.temperature }),
   })
-  return result.text
+  return result.output
 }

--- a/apps/api/src/lib/ai/categorize.ts
+++ b/apps/api/src/lib/ai/categorize.ts
@@ -1,4 +1,4 @@
-import { generateText, Output } from 'ai'
+import { generateText, NoObjectGeneratedError, Output } from 'ai'
 import * as z from 'zod'
 
 import {
@@ -256,38 +256,59 @@ type BulkCategorizationModelArgs = {
 
 export function callBulkCategorizationModel(
   args: BulkCategorizationModelArgs & { operation: 'bulk-calibration' },
-): Promise<CalibrationResponse>
+): Promise<CalibrationResponse | undefined>
 export function callBulkCategorizationModel(
   args: BulkCategorizationModelArgs & { operation: 'bulk-preview' },
-): Promise<BulkPreviewResponse>
+): Promise<BulkPreviewResponse | undefined>
 export async function callBulkCategorizationModel(
   args: BulkCategorizationModelArgs,
-): Promise<CalibrationResponse | BulkPreviewResponse> {
-  const output =
+): Promise<CalibrationResponse | BulkPreviewResponse | undefined> {
+  const model = await getModel(args.prompt.model)
+  const supportsStructuredOutputs = !(
+    typeof model === 'object' &&
+    model !== null &&
+    'supportsStructuredOutputs' in model &&
+    model.supportsStructuredOutputs === false
+  )
+  const metadata =
     args.operation === 'bulk-calibration'
-      ? Output.object({
+      ? {
           name: 'bulk_calibration',
           description:
             'Representative expenses to review before bulk categorization.',
-          schema: calibrationModelResponseSchema,
-        })
-      : Output.object({
+        }
+      : {
           name: 'bulk_category_preview',
           description: 'Category suggestions for a chunk of expenses.',
-          schema: bulkPreviewModelResponseSchema,
-        })
+        }
+  const output = !supportsStructuredOutputs
+    ? Output.json(metadata)
+    : args.operation === 'bulk-calibration'
+      ? Output.object({ ...metadata, schema: calibrationModelResponseSchema })
+      : Output.object({ ...metadata, schema: bulkPreviewModelResponseSchema })
 
-  const result = await generateText({
-    model: await getModel(args.prompt.model),
-    instructions: args.prompt.instructions,
-    prompt: args.prompt.prompt,
-    output,
-    reasoning: 'none',
-    maxRetries: BULK_CATEGORIZATION_MAX_RETRIES,
-    timeout: BULK_CATEGORIZATION_TIMEOUT_MS,
-    ...(args.prompt.temperature === undefined
-      ? {}
-      : { temperature: args.prompt.temperature }),
-  })
-  return result.output
+  try {
+    const result = await generateText({
+      model,
+      instructions: args.prompt.instructions,
+      prompt: args.prompt.prompt,
+      output,
+      reasoning: 'none',
+      maxRetries: BULK_CATEGORIZATION_MAX_RETRIES,
+      timeout: BULK_CATEGORIZATION_TIMEOUT_MS,
+      ...(args.prompt.temperature === undefined
+        ? {}
+        : { temperature: args.prompt.temperature }),
+    })
+    const parsed =
+      args.operation === 'bulk-calibration'
+        ? calibrationResponseSchema.safeParse(result.output)
+        : bulkPreviewResponseSchema.safeParse(result.output)
+    return parsed.success ? parsed.data : undefined
+  } catch (cause) {
+    // Preserve the callers' existing malformed-response handling while
+    // allowing provider, timeout, and rate-limit errors to propagate.
+    if (NoObjectGeneratedError.isInstance(cause)) return undefined
+    throw cause
+  }
 }

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
@@ -144,23 +144,21 @@ export const aiBulkCategorizeCalibrateProcedure = protectedProcedure
       'ai.bulkCategorize.calibrate',
       ctx.resHeaders,
     )
-    let parsed: CalibrationResponse
-    try {
-      parsed = calibrationResponseSchema.parse(
-        await callBulkCategorizationModel({
-          operation: 'bulk-calibration',
-          candidateCount: candidates.length,
-          priorFeedbackCount: priorFeedback.length,
-          round: input.round,
-          prompt: {
-            model: env.AI_CATEGORY_MODEL,
-            temperature: 0.1,
-            instructions: system,
-            prompt: userContent,
-          },
-        }),
-      )
-    } catch {
+    const raw = await callBulkCategorizationModel({
+      operation: 'bulk-calibration',
+      candidateCount: candidates.length,
+      priorFeedbackCount: priorFeedback.length,
+      round: input.round,
+      prompt: {
+        model: env.AI_CATEGORY_MODEL,
+        temperature: 0.1,
+        instructions: system,
+        prompt: userContent,
+      },
+    })
+
+    const parsed = calibrationResponseSchema.safeParse(raw)
+    if (!parsed.success) {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message:
@@ -175,7 +173,7 @@ export const aiBulkCategorizeCalibrateProcedure = protectedProcedure
       priorFeedback.map((selection) => selection.expenseId),
     )
     const selectedIds = new Set<string>()
-    const selectedForReview = parsed.selections.filter((selection) => {
+    const selectedForReview = parsed.data.selections.filter((selection) => {
       if (
         !candidateIds.has(selection.expenseId) ||
         reviewedIds.has(selection.expenseId) ||
@@ -188,8 +186,8 @@ export const aiBulkCategorizeCalibrateProcedure = protectedProcedure
     })
 
     if (
-      (input.round === 1 && !parsed.needsFeedback) ||
-      (parsed.needsFeedback && selectedForReview.length === 0)
+      (input.round === 1 && !parsed.data.needsFeedback) ||
+      (parsed.data.needsFeedback && selectedForReview.length === 0)
     ) {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
@@ -207,8 +205,8 @@ export const aiBulkCategorizeCalibrateProcedure = protectedProcedure
       })),
       totalEligible,
       response: {
-        needsFeedback: parsed.needsFeedback,
-        selections: parsed.needsFeedback ? selectedForReview : [],
+        needsFeedback: parsed.data.needsFeedback,
+        selections: parsed.data.needsFeedback ? selectedForReview : [],
       } satisfies CalibrationResponse,
       forcedReady: false,
     }

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.ts
@@ -144,23 +144,22 @@ export const aiBulkCategorizeCalibrateProcedure = protectedProcedure
       'ai.bulkCategorize.calibrate',
       ctx.resHeaders,
     )
-    const raw = await callBulkCategorizationModel({
-      operation: 'bulk-calibration',
-      candidateCount: candidates.length,
-      priorFeedbackCount: priorFeedback.length,
-      round: input.round,
-      prompt: {
-        model: env.AI_CATEGORY_MODEL,
-        temperature: 0.1,
-        instructions: system,
-        prompt: userContent,
-      },
-    })
-
     let parsed: CalibrationResponse
     try {
-      const json = JSON.parse(raw ?? '{}')
-      parsed = calibrationResponseSchema.parse(json)
+      parsed = calibrationResponseSchema.parse(
+        await callBulkCategorizationModel({
+          operation: 'bulk-calibration',
+          candidateCount: candidates.length,
+          priorFeedbackCount: priorFeedback.length,
+          round: input.round,
+          prompt: {
+            model: env.AI_CATEGORY_MODEL,
+            temperature: 0.1,
+            instructions: system,
+            prompt: userContent,
+          },
+        }),
+      )
     } catch {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
@@ -120,44 +120,21 @@ export const aiBulkCategorizePreviewProcedure = protectedProcedure
         chunk,
         priorFeedback,
       })
-      const raw = await callBulkCategorizationModel({
-        operation: 'bulk-preview',
-        candidateCount: chunk.length,
-        priorFeedbackCount: priorFeedback.length,
-        prompt: {
-          model: env.AI_CATEGORY_MODEL,
-          temperature: 0.1,
-          instructions: system,
-          prompt: userContent,
-        },
-      })
       let parsed: BulkPreviewResponse
       try {
-        const obj = JSON.parse(raw ?? '{}')
-        // The schema rejects unknown category ids, so a model
-        // hallucination produces a parse error instead of an
-        // untyped row.
-        parsed = bulkPreviewResponseSchema.parse({
-          suggestions: Array.isArray(obj.suggestions)
-            ? obj.suggestions.filter(
-                (
-                  s: unknown,
-                ): s is {
-                  expenseId: string
-                  suggestedCategoryId: string
-                  confidence: string
-                } =>
-                  typeof s === 'object' &&
-                  s !== null &&
-                  typeof (s as { expenseId?: unknown }).expenseId ===
-                    'string' &&
-                  typeof (s as { suggestedCategoryId?: unknown })
-                    .suggestedCategoryId === 'string' &&
-                  typeof (s as { confidence?: unknown }).confidence ===
-                    'string',
-              )
-            : [],
-        })
+        parsed = bulkPreviewResponseSchema.parse(
+          await callBulkCategorizationModel({
+            operation: 'bulk-preview',
+            candidateCount: chunk.length,
+            priorFeedbackCount: priorFeedback.length,
+            prompt: {
+              model: env.AI_CATEGORY_MODEL,
+              temperature: 0.1,
+              instructions: system,
+              prompt: userContent,
+            },
+          }),
+        )
       } catch {
         // Skip this chunk; the UI shows the surviving rows and
         // the admin can correct the rest manually.

--- a/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
+++ b/apps/api/src/trpc/routers/ai/bulkCategorize/preview.procedure.ts
@@ -120,27 +120,24 @@ export const aiBulkCategorizePreviewProcedure = protectedProcedure
         chunk,
         priorFeedback,
       })
-      let parsed: BulkPreviewResponse
-      try {
-        parsed = bulkPreviewResponseSchema.parse(
-          await callBulkCategorizationModel({
-            operation: 'bulk-preview',
-            candidateCount: chunk.length,
-            priorFeedbackCount: priorFeedback.length,
-            prompt: {
-              model: env.AI_CATEGORY_MODEL,
-              temperature: 0.1,
-              instructions: system,
-              prompt: userContent,
-            },
-          }),
-        )
-      } catch {
+      const raw = await callBulkCategorizationModel({
+        operation: 'bulk-preview',
+        candidateCount: chunk.length,
+        priorFeedbackCount: priorFeedback.length,
+        prompt: {
+          model: env.AI_CATEGORY_MODEL,
+          temperature: 0.1,
+          instructions: system,
+          prompt: userContent,
+        },
+      })
+      const parsed = bulkPreviewResponseSchema.safeParse(raw)
+      if (!parsed.success) {
         // Skip this chunk; the UI shows the surviving rows and
         // the admin can correct the rest manually.
         continue
       }
-      for (const s of parsed.suggestions) {
+      for (const s of parsed.data.suggestions) {
         if (!candidateIds.has(s.expenseId)) continue
         if (seenIds.has(s.expenseId)) continue
         seenIds.add(s.expenseId)


### PR DESCRIPTION
## Summary

Replace manual parsing of prompt-requested JSON in bulk categorization with AI SDK output handling. Providers with structured-output support use schema-bound output; adapters that explicitly lack it use JSON mode followed by the existing tolerant allowlist schema.

Closes #89

## Changes

- Use `Output.object(...)` and `result.output` for bulk calibration and preview.
- Keep strict model-facing Zod schemas compatible with OpenAI structured outputs while preserving the tolerant public parsers used by existing callers.
- Use `Output.json(...)` plus the tolerant public parser when a model explicitly reports that structured outputs are unsupported.
- Preserve malformed-response handling without swallowing provider, timeout, or transport failures.
- Restrict generated category IDs and confidence values through the schemas.
- Add focused regression tests for calibration and preview, including absent or malformed `text` responses and bounded generation settings.

## Verification

- [x] `bun run check`
- [ ] `bun run test` (not run because PostgreSQL is not available locally)
- [x] I added or updated tests where appropriate.

Additional focused verification:

```text
bun --env-file=apps/api/.env.test apps/api/node_modules/.bin/vitest run --globals apps/api/src/lib/ai/categorize.test.ts apps/api/src/lib/ai/categorize-limits.test.ts apps/api/src/trpc/routers/ai/bulkCategorize/calibrate.procedure.test.ts

Test Files  3 passed (3)
Tests       17 passed (17)
```

`git diff --check` also passes. The fix was production-tested with `gpt-5.6-luna`; calibration succeeded after deployment.

## AI-assisted development disclosure

- [ ] No AI assistance was used.
- [x] AI was used, and I included the initial prompt plus all materially relevant follow-up prompts below (with notes on important changes or decisions).

### Prompt history

Initial prompt: "let's deploy the mcp connector and category suggestions using gpt 5.6 luna"

Follow-up: "i enabled bulk categorization too. what reasoning level do we use?"

Failure report: "Could not run calibration: The AI returned an unexpected calibration response. Please try again. when i ran the bulk"

Follow-up: "explain the first commit"

Review follow-up: "let's do both" after reviewing the actionable comments on this PR and the MCP container PR.

The implementation replaced manual text JSON parsing with AI SDK output handling. Review feedback led to a JSON-mode fallback for adapters without structured-output support and restoration of provider-error propagation. The human reviewed and production-tested the original result; focused regression tests cover both output paths.

## Checklist

- [x] The implementation is complete and I have reviewed all AI-generated code.
- [x] Documentation is updated when needed. (No documentation change is needed.)
- [x] Schema changes include the schema, migration, and generated client. (No database schema changes.)
- [x] This PR contains one logical change.
- [x] Related issue: `Closes #89`
