### PR TITLE
chore(security): run MCP container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN find apps/mcp/dist -type f -name '*.map' -delete
 FROM node:24.12.0-bookworm-slim AS mcp
 WORKDIR /app/apps/mcp
 ENV NODE_ENV=production
-COPY --from=mcp-builder /app/apps/mcp/dist ./dist
+COPY --chown=node:node --from=mcp-builder /app/apps/mcp/dist ./dist
+USER node
 EXPOSE 3002
 CMD ["node", "dist/runtime.mjs"]


### PR DESCRIPTION
## Summary

Run the MCP runtime container as the non-root `node` user provided by the base image. The copied runtime bundle is owned by that user so the service can read it without root privileges.

## Changes

- Copy the MCP runtime bundle with `node:node` ownership.
- Set `USER node` in the final MCP image.

## Verification

- [x] `bun run check`
- [ ] `bun run test` (not run; this Dockerfile-only change has no application behavior changes)
- [x] I added or updated tests where appropriate. (Verified through an image build and runtime user inspection.)

Additional verification:

```text
docker build --target mcp --build-arg APP_SCOPE=@spliit/mcp -t spliit-mcp-non-root-test .
# passed

docker image inspect spliit-mcp-non-root-test --format '{{.Config.User}}'
node

docker run --rm --entrypoint id spliit-mcp-non-root-test
uid=1000(node) gid=1000(node) groups=1000(node)

# Follow-up review verification: boot the actual production server.
docker run --detach --rm --name spliit-mcp-non-root-review \
  --publish 127.0.0.1:33002:3002 \
  --env NODE_ENV=production \
  --env MCP_PUBLIC_URL=http://127.0.0.1:33002 \
  --env MCP_API_URL=http://127.0.0.1:39999 \
  --env MCP_WEB_URL=http://127.0.0.1:39998 \
  spliit-mcp-non-root-review

# Server startup completed and the health route responded inside the container.
GET http://[::1]:3002/health
200 {"status":"ok"}

# Production startup rewrote the manifest successfully as the node user.
{"uid":1000,"gid":1000,"domain":"http://127.0.0.1:33002"}
```

`git diff --check` also passes.

## AI-assisted development disclosure

- [ ] No AI assistance was used.
- [x] AI was used, and I included the initial prompt plus all materially relevant follow-up prompts below (with notes on important changes or decisions).

### Prompt history

Initial prompt: "read upstream-ai-mcp contributions doc and execute"

Review follow-up: "let's do both" after reviewing the actionable comments on this PR and the AI structured-output PR.

The contribution handoff explicitly scoped this PR to changing MCP runtime bundle ownership and setting the final image user. Review feedback led to an end-to-end production boot check that confirmed the manifest rewrite, server startup, and health endpoint all work as uid/gid 1000. No deployment configuration or private environment details are included.

## Checklist

- [x] The implementation is complete and I have reviewed all AI-generated code.
- [x] Documentation is updated when needed. (No documentation change is needed.)
- [x] Schema changes include the schema, migration, and generated client. (No database schema changes.)
- [x] This PR contains one logical change.
- [x] Related issue: Not applicable; standalone container hardening.
