### PR TITLE
Fix PDF report generation in self-hosted setup.

### DIFF
--- a/nginx.web.conf
+++ b/nginx.web.conf
@@ -71,7 +71,7 @@ server {
     proxy_pass http://api:3001;
   }
 
-  location ~ ^/groups/[^/]+/expenses/export/(json|csv)$ {
+  location ~ ^/groups/[^/]+/expenses/(export/(json|csv)|report-data)$ {
     proxy_pass http://api:3001;
   }
 


### PR DESCRIPTION
## Summary

Needed endpoint (`/groups/.../expenses/report-data`) wasn't proxied to api server.

## Changes

Tweaked a location regexp in nginx.web.conf.

## Verification

Tested on my self-hosted setup.

## AI-assisted development disclosure

<!-- AI agent contributions are welcome. If AI was used, choose one of the two
     options below and include the requested material. Redact secrets and
     private data from prompts. -->

- [x] No AI assistance was used.
- [ ] AI was used, and I included the initial prompt plus all materially
      relevant follow-up prompts below (with notes on important changes or
      decisions).

## Checklist

- [x] The implementation is complete and I have reviewed all AI-generated code.
- [x] Documentation is updated when needed.
- [x] Schema changes include the schema, migration, and generated client.
- [x] This PR contains one logical change.
- [ ] Related issue: `Closes #...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group expense report-data requests are now correctly routed through the API proxy.
  * Existing JSON and CSV export routes remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->