### PR TITLE
fix: make .env.example boot from a clean clone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,13 +28,17 @@ VITE_API_URL="http://localhost:3001"
 BETTER_AUTH_URL="http://localhost:3001"
 WEB_ORIGINS="http://localhost:3000"
 
-# MCP-only settings. ChatGPT and Claude cannot reach localhost. Start one
-# tunnel per local service, copy the HTTPS URLs they print, and replace the
-# sample origins:
-# The MCP server uses these values to reach the public OAuth/API/web origins.
-MCP_PUBLIC_URL="cloudflared tunnel --url http://localhost:3002"
-MCP_API_URL="cloudflared tunnel --url http://localhost:3001"
-MCP_WEB_URL="cloudflared tunnel --url http://localhost:3000"
+# MCP-only settings. The MCP server uses these values to reach the public
+# OAuth/API/web origins. Localhost defaults keep `bun dev` and the Inspector
+# working out of the box.
+# ChatGPT and Claude cannot reach localhost. To connect them, start one tunnel
+# per local service and replace each value below with the HTTPS URL it prints:
+#   cloudflared tunnel --url http://localhost:3002  # MCP
+#   cloudflared tunnel --url http://localhost:3001  # API
+#   cloudflared tunnel --url http://localhost:3000  # Web
+MCP_PUBLIC_URL="http://localhost:3002"
+MCP_API_URL="http://localhost:3001"
+MCP_WEB_URL="http://localhost:3000"
 # API-only: encrypts assistant confirmation tokens. Never share with MCP or
 # reuse BETTER_AUTH_SECRET. Generate with: openssl rand -hex 32
 ASSISTANT_CONFIRMATION_SECRET=
@@ -61,9 +65,11 @@ EMAIL_FROM="Spliit Cloud Local <no-reply@spliit.local>"
 
 # Web Push (generate with `bunx web-push generate-vapid-keys`). Required
 # together in production; keep the private key secret.
+# All three must be set together, or all three left empty. A subject without
+# the key pair fails env validation and the API refuses to start.
 PUSH_VAPID_PUBLIC_KEY=
 PUSH_VAPID_PRIVATE_KEY=
-PUSH_VAPID_SUBJECT=mailto:admin@yourdomain.com
+PUSH_VAPID_SUBJECT=
 
 # Stateless optional-email unsubscribe links. Generate with:
 #   openssl rand -hex 32


### PR DESCRIPTION
`.env.example` doesn't boot from a clean clone, in two separate ways.

The three `MCP_*` values are the `cloudflared` command lines from `docs/mcp-publishing.md`, pasted in as values rather than as the commands they are. Zod rejects them, `apps/mcp/config.ts` throws on `new URL()`, and turbo takes the whole `bun dev` down with it. So a fresh contributor following CONTRIBUTING.md gets no web and no API, only a stack trace from the MCP app.

And `PUSH_VAPID_SUBJECT` ships filled in while both key values are empty, which trips the configured-together check in `lib/env.ts` and stops the API from booting at all.

Both are now localhost defaults / empty, with the tunnel commands moved into comments where they belong. Verified by loading `apps/api/src/lib/env.ts` and `apps/mcp/config.ts` directly against the corrected file: both validate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified local MCP development configuration and separated tunnel command examples from URL settings.
  * Updated Web Push configuration guidance to require all VAPID variables together.
  * Removed the sample email subject, leaving the setting blank by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->