### PR TITLE
Import from Cospend

### DIFF
--- a/apps/api/src/lib/api/recurrence/series-ops.ts
+++ b/apps/api/src/lib/api/recurrence/series-ops.ts
@@ -117,8 +117,8 @@ export async function createSeriesForExpense(args: {
   /** Import / backfill: how many historical occurrences already exist. */
   occurrencesCreated?: number
   /** Import / backfill: explicit next cursor (e.g. first date after today). */
-  nextOccurrenceDate?: Date
-  nextOccurrenceOrdinal?: number
+  nextOccurrenceDate?: Date | null
+  nextOccurrenceOrdinal?: number | null
 }) {
   const timeZone = args.timeZone
   const nextOrdinal = args.nextOccurrenceOrdinal ?? 2
@@ -132,7 +132,9 @@ export async function createSeriesForExpense(args: {
     )
   const occurrencesCreated = args.occurrencesCreated ?? 1
   const fields = toSeriesFields(args.config)
-  const completed = initialSeriesCompleted(fields, args.anchorDate, nextDate)
+  const completed =
+    args.nextOccurrenceDate === null ||
+    initialSeriesCompleted(fields, args.anchorDate, nextDate)
   const anchorTimeMinutes = args.anchorTimeMinutes
   const series = await args.tx.recurringExpenseSeries.create({
     data: {

--- a/apps/api/src/trpc/outputs/imports.ts
+++ b/apps/api/src/trpc/outputs/imports.ts
@@ -40,7 +40,7 @@ const normalizedSourceExpenseSchema = z.object({
 })
 
 export const normalizedSourceSchema = z.object({
-  provider: z.enum(['SPLIIT', 'SPLITWISE']),
+  provider: z.enum(['SPLIIT', 'SPLITWISE', 'COSPEND']),
   exportVersion: z.literal(3).nullable().optional(),
   sourceGroupId: z.string(),
   sourceUrl: z.string().nullable(),

--- a/apps/api/src/trpc/routers/groups/import.procedure.ts
+++ b/apps/api/src/trpc/routers/groups/import.procedure.ts
@@ -79,28 +79,29 @@ const historicalActivitySchema = z.object({
 })
 
 /**
- * Spliit imports intentionally remain the immutable legacy spliit.app
- * transport. Internal Cloud series metadata is never accepted here; legacy
- * recurrenceRule values are mapped to collapsed destination series.
+ * Imports carry the legacy `recurrenceRule` plus, when the source supports it,
+ * an authoritative `recurrence` config (frequency + interval + end). The config
+ * is validated by `expenseApiSchema` and preferred over the legacy rule when
+ * planning destination series (e.g. Cospend's yearly / multi-interval /
+ * dated-end schedules). `expenseTimeZone` is always normalized to UTC.
  */
 export const importExpenseSchema = z.preprocess((value) => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return value
-  const {
-    recurrence: _recurrence,
-    expenseTimeZone: _expenseTimeZone,
-    ...legacyExpense
-  } = value as Record<string, unknown>
-  const rawExpenseDate = legacyExpense.expenseDate
+  const { expenseTimeZone: _expenseTimeZone, ...expense } = value as Record<
+    string,
+    unknown
+  >
+  const rawExpenseDate = expense.expenseDate
   const expenseDate =
     rawExpenseDate instanceof Date
       ? rawExpenseDate
       : typeof rawExpenseDate === 'string' || typeof rawExpenseDate === 'number'
         ? new Date(rawExpenseDate)
         : null
-  if (!expenseDate || Number.isNaN(expenseDate.getTime())) return legacyExpense
+  if (!expenseDate || Number.isNaN(expenseDate.getTime())) return expense
 
   return {
-    ...legacyExpense,
+    ...expense,
     expenseDate: new Date(
       Date.UTC(
         expenseDate.getUTCFullYear(),

--- a/apps/web/src/app/groups/import/confirm-step.tsx
+++ b/apps/web/src/app/groups/import/confirm-step.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import type { AppRouterOutput } from '@spliit/api/router'
-import type { NormalizedSource } from '@spliit/domain/import'
+import type { NormalizedSource, RecurrenceConfig } from '@spliit/domain/import'
 import {
   collapseExpenseFromNormalized,
   summarizeLegacyRecurringImport,
@@ -121,15 +121,46 @@ export function ConfirmStep({
         ),
       )
 
-  const recurrenceRuleLabel = (rule: 'DAILY' | 'WEEKLY' | 'MONTHLY') => {
-    switch (rule) {
-      case 'DAILY':
-        return t('Groups.Import.Confirm.recurrenceRule.daily')
-      case 'WEEKLY':
-        return t('Groups.Import.Confirm.recurrenceRule.weekly')
-      case 'MONTHLY':
-        return t('Groups.Import.Confirm.recurrenceRule.monthly')
+  const recurrenceConfigLabel = (config: RecurrenceConfig) => {
+    if (config.interval === 1) {
+      switch (config.frequency) {
+        case 'DAILY':
+          return t('Groups.Import.Confirm.recurrenceRule.daily')
+        case 'WEEKLY':
+          return t('Groups.Import.Confirm.recurrenceRule.weekly')
+        case 'MONTHLY':
+          return t('Groups.Import.Confirm.recurrenceRule.monthly')
+        case 'YEARLY':
+          return t('Groups.Import.Confirm.recurrenceRule.yearly')
+      }
     }
+    let frequency: string
+    switch (config.frequency) {
+      case 'DAILY':
+        frequency = t(
+          'Groups.Import.Confirm.recurrenceSchedule.frequency.daily',
+        )
+        break
+      case 'WEEKLY':
+        frequency = t(
+          'Groups.Import.Confirm.recurrenceSchedule.frequency.weekly',
+        )
+        break
+      case 'MONTHLY':
+        frequency = t(
+          'Groups.Import.Confirm.recurrenceSchedule.frequency.monthly',
+        )
+        break
+      case 'YEARLY':
+        frequency = t(
+          'Groups.Import.Confirm.recurrenceSchedule.frequency.yearly',
+        )
+        break
+    }
+    return t('Groups.Import.Confirm.recurrenceSchedule.every', {
+      interval: config.interval,
+      frequency,
+    })
   }
 
   return (
@@ -195,11 +226,11 @@ export function ConfirmStep({
                 <ul className="ms-4 list-disc space-y-1 text-muted-foreground">
                   {recurringSchedules.map((schedule, index) => (
                     <li
-                      key={`${index}:${schedule.title}:${schedule.recurrenceRule}`}
+                      key={`${index}:${schedule.title}:${schedule.config.frequency}:${schedule.config.interval}`}
                     >
                       {t('Groups.Import.Confirm.recurringScheduleItem', {
                         title: schedule.title,
-                        rule: recurrenceRuleLabel(schedule.recurrenceRule),
+                        rule: recurrenceConfigLabel(schedule.config),
                       })}
                     </li>
                   ))}

--- a/apps/web/src/app/groups/import/source-providers.ts
+++ b/apps/web/src/app/groups/import/source-providers.ts
@@ -1,4 +1,5 @@
 import {
+  tryParseCospendCsv,
   tryParseSpliitCsv,
   tryParseSpliitExport,
   tryParseSplitwiseCsv,
@@ -9,6 +10,7 @@ export type SourceMode =
   | 'spliit'
   | 'spliit-cloud'
   | 'splitwise'
+  | 'cospend'
   | 'tricount'
   | 'settleup'
 
@@ -44,6 +46,12 @@ export const PROVIDERS: Record<SourceMode, ProviderConfig> = {
     hasUrlPaste: false,
     hasDomainSwap: false,
     fileImport: { csv: tryParseSplitwiseCsv },
+    accept: '.csv,text/csv',
+  },
+  cospend: {
+    hasUrlPaste: false,
+    hasDomainSwap: false,
+    fileImport: { csv: tryParseCospendCsv },
     accept: '.csv,text/csv',
   },
   tricount: {

--- a/apps/web/src/app/groups/import/source-step.test.tsx
+++ b/apps/web/src/app/groups/import/source-step.test.tsx
@@ -80,6 +80,7 @@ describe('SourceStep — initialError (prefill) handling', () => {
       'Spliit',
       'Spliit Cloud',
       'Splitwise',
+      'Cospend',
       'Tricount (coming soon)',
       'Settle Up (coming soon)',
     ])
@@ -90,6 +91,7 @@ describe('SourceStep — initialError (prefill) handling', () => {
       'spliit',
       'spliit-cloud',
       'splitwise',
+      'cospend',
       'tricount',
       'settleup',
     ] as const

--- a/apps/web/src/app/groups/import/source-step.test.tsx
+++ b/apps/web/src/app/groups/import/source-step.test.tsx
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fireEvent, render, screen } from '@/test/test-utils'
 
+import type { SourceMode } from './source-providers'
 import { SourceStep } from './source-step'
 
 // jsdom doesn't implement scrollIntoView; the SourceStep mount effect
@@ -16,12 +17,7 @@ beforeAll(() => {
 // ── Module mocks ────────────────────────────────────────────────────────
 
 const routerMocks = vi.hoisted(() => ({
-  source: 'spliit' as
-    | 'spliit'
-    | 'spliit-cloud'
-    | 'splitwise'
-    | 'tricount'
-    | 'settleup',
+  source: 'spliit' as SourceMode,
   navigate: vi.fn(),
 }))
 

--- a/apps/web/src/app/groups/import/source-step.tsx
+++ b/apps/web/src/app/groups/import/source-step.tsx
@@ -318,6 +318,7 @@ export function SourceStep({
   const showDomainSwap = cfg.hasDomainSwap
   const showUrlPaste = cfg.hasUrlPaste
   const isSplitwise = provider === 'splitwise'
+  const isCospend = provider === 'cospend'
   const isCloud = provider === 'spliit-cloud'
 
   return (
@@ -423,6 +424,16 @@ export function SourceStep({
               {t('Groups.Import.Source.splitwise')}
             </TabsTrigger>
             <TabsTrigger
+              value="cospend"
+              className="min-w-max"
+              nativeButton={false}
+              render={
+                <Link to="/groups/import" search={{ source: 'cospend' }} />
+              }
+            >
+              {t('Groups.Import.Source.cospend')}
+            </TabsTrigger>
+            <TabsTrigger
               value="tricount"
               className="min-w-max"
               nativeButton={false}
@@ -474,6 +485,19 @@ export function SourceStep({
             />
           </PageInset>
           <SplitwiseAnonymizerCard />
+        </TabsContent>
+        <TabsContent value="cospend">
+          <PageInset>
+            <ProviderDescription
+              description={t('Groups.Import.Source.cospendDescription')}
+              receiptTitle={t(
+                'Groups.Import.Source.receiptWarningTitleCospend',
+              )}
+              receiptDescription={t(
+                'Groups.Import.Source.receiptWarningDescriptionCospend',
+              )}
+            />
+          </PageInset>
         </TabsContent>
         <TabsContent value="tricount">
           <ComingSoonCard
@@ -537,14 +561,18 @@ export function SourceStep({
                 ? 'Groups.Import.Source.cloudZipRequired'
                 : isSplitwise
                   ? 'Groups.Import.Source.dropFileSplitwise'
-                  : 'Groups.Import.Source.dropFile',
+                  : isCospend
+                    ? 'Groups.Import.Source.dropFileCospend'
+                    : 'Groups.Import.Source.dropFile',
             ),
             dropFileDescription: t(
               isCloud
                 ? 'Groups.Import.Source.spliitCloudScopeDescription'
                 : isSplitwise
                   ? 'Groups.Import.Source.dropFileDescriptionSplitwise'
-                  : 'Groups.Import.Source.dropFileDescription',
+                  : isCospend
+                    ? 'Groups.Import.Source.dropFileDescriptionCospend'
+                    : 'Groups.Import.Source.dropFileDescription',
             ),
           }}
         />

--- a/apps/web/src/app/groups/import/source-step.tsx
+++ b/apps/web/src/app/groups/import/source-step.tsx
@@ -219,7 +219,10 @@ export function SourceStep({
           onError(parsed.error)
           return
         }
-        const guessed = guessGroupNameFromFilename(file.name)
+        const guessed = guessGroupNameFromFilename(
+          file.name,
+          parsed.source.provider,
+        )
         if (guessed) parsed.source.name = guessed
         onLoaded(parsed.source)
       } catch (err) {

--- a/apps/web/src/messages/ar-SA.json
+++ b/apps/web/src/messages/ar-SA.json
@@ -837,12 +837,18 @@
         "csvRecurrenceLimitation": "لا يتضمن تصدير CSV التكرارات. استخدم تصدير JSON من spliit.app لاستيراد المصروفات المتكررة.",
         "fileReadError": "فشل في قراءة الملف",
         "receiptWarningDescription": "لا يتضمن تصدير spliit.app صور الإيصالات. أعد رفعها في المجموعة الهدف إذا احتجتها.",
+        "cospendDescription": "أسقط تصدير CSV لمشروع Cospend لاستيراد أعضائه وفواتيره وجداول الدفع المتكررة إلى Spliit Cloud. قم بتصدير المشروع من إعدادات Cospend (ملف CSV واحد لكل مشروع). تحتفظ الفواتير المتكررة بجدولها — التكرار السنوي وتعدد الفترات والتواريخ المحددة للنهاية كلها مدعومة.",
+        "receiptWarningTitleCospend": "لا يتم استيراد صور الإيصالات.",
+        "receiptWarningDescriptionCospend": "لا يتضمن تصدير Cospend صور الإيصالات. أعد رفعها في المجموعة المستهدفة إذا كنت بحاجة إليها.",
+        "dropFileCospend": "أسقط ملف CSV من Cospend، أو انقر للاختيار",
+        "dropFileDescriptionCospend": "يصدر Cospend ملف CSV واحداً لكل مشروع. نستورد الأعضاء وكل فاتورة وجداول التكرار. العملة الأساسية للمشروع هي EUR افتراضياً عندما لا يحددها التصدير — تحقق منها في الخطوة التالية.",
         "unsupportedFileType": "نوع ملف غير مدعوم. يرجى إسقاط ملف JSON أو CSV.",
         "receiptWarningDescriptionSplitwise": "لا يتضمن تصدير Splitwise صور الإيصالات. أعد رفعها في المجموعة الهدف إذا احتجتها.",
         "fromSpliit": "سبيليت",
         "fetchGroupButton": "استيراد مجموعة",
         "urlDescription": "يجلب خادمنا المجموعة عبر نقطة نهاية التصدير العامة لـ spliit.app نيابة عنك.",
         "settleUpComingTitle": "استيراد Settle Up قادم قريباً",
+        "cospend": "Cospend",
         "tricount": "Tricount (قريباً)",
         "receiptWarningTitleSplitwise": "لا يتم استيراد صور الإيصالات.",
         "fetchingButton": "جارٍ الاستيراد…",
@@ -965,7 +971,8 @@
         "recurrenceRule": {
           "weekly": "أسبوعي",
           "daily": "يومي",
-          "monthly": "شهري"
+          "monthly": "شهري",
+          "yearly": "سنوي"
         },
         "footer": "سيتم استيراد كل مشارك مصدري ومصروفاته. ادعُ المرسل/المنشئ بعد إنشاء المجموعة.",
         "currencyRateFormat": "1 {source} = {rate} {target}",
@@ -1000,7 +1007,16 @@
         "importButton": "استيراد مجموعة",
         "existingGroupFormat": "مجموعة موجودة · مدمجة",
         "currencyConversionTitle": "تحويل العملة",
-        "documentCount": "المستندات: تم استرداد {imported}، وتخطّي {skipped}"
+        "documentCount": "المستندات: تم استرداد {imported}، وتخطّي {skipped}",
+        "recurrenceSchedule": {
+          "every": "كل {interval} {frequency}",
+          "frequency": {
+            "daily": "أيام",
+            "weekly": "أسابيع",
+            "monthly": "أشهر",
+            "yearly": "سنوات"
+          }
+        }
       },
       "Documents": {
         "title": "اصطحب إيصالاتك معك",

--- a/apps/web/src/messages/bn-BD.json
+++ b/apps/web/src/messages/bn-BD.json
@@ -1917,9 +1917,19 @@
         "recurrenceRule": {
           "daily": "দৈনিক",
           "weekly": "সাপ্তাহিক",
-          "monthly": "মাসিক"
+          "monthly": "মাসিক",
+          "yearly": "বার্ষিক"
         },
-        "documentCount": "নথি: {imported}টি উদ্ধার হয়েছে, {skipped}টি বাদ গেছে"
+        "documentCount": "নথি: {imported}টি উদ্ধার হয়েছে, {skipped}টি বাদ গেছে",
+        "recurrenceSchedule": {
+          "every": "প্রতি {interval} {frequency}",
+          "frequency": {
+            "daily": "দিন",
+            "weekly": "সপ্তাহ",
+            "monthly": "মাস",
+            "yearly": "বছর"
+          }
+        }
       },
       "CurrencyConversion": {
         "pairSection": "{source} → {target}",
@@ -2013,6 +2023,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (শীঘ্রই আসছে)",
         "settleUp": "Settle Up (শীঘ্রই আসছে)",
         "spliitDescription": "একটি বিদ্যমান spliit.app গ্রুপকে Spliit Cloud-এ আনুন। আমরা গ্রুপের নাম, অংশগ্রহণকারী এবং প্রতিটি খরচ পড়ি।",
@@ -2041,6 +2052,11 @@
         "splitwiseDescription": "একটি Splitwise CSV এক্সপোর্ট ড্রপ করে এর খরচ Spliit Cloud-এ আমদানি করুন। ফাইলটি Splitwise-এর গ্রুপ এক্সপোর্ট থেকে হতে হবে — গ্রুপের সেটিংস থেকে উপলব্ধ প্রতি-গ্রুপ CSV।",
         "receiptWarningTitleSplitwise": "রসিদের ছবি আমদানি করা হয় না।",
         "receiptWarningDescriptionSplitwise": "Splitwise এক্সপোর্টে রসিদের ছবি অন্তর্ভুক্ত নয়। প্রয়োজন হলে গন্তব্য গ্রুপে পুনরায় আপলোড করুন।",
+        "cospendDescription": "Cospend প্রজেক্ট CSV এক্সপোর্ট ড্রপ করে সদস্য, বিল এবং পুনরাবৃত্ত সময়সূচী Spliit Cloud-এ আমদানি করুন। Cospend-এর সেটিংস থেকে প্রজেক্ট এক্সপোর্ট করুন (প্রতি প্রজেক্টে একটি CSV)। পুনরাবৃত্ত বিল তাদের সময়সূচী বজায় রাখে — বার্ষিক, বহু-ব্যবধান এবং শেষ তারিখের পুনরাবৃত্তি সমর্থিত।",
+        "receiptWarningTitleCospend": "রসিদের ছবি আমদানি করা হয় না।",
+        "receiptWarningDescriptionCospend": "Cospend এক্সপোর্টে রসিদের ছবি অন্তর্ভুক্ত থাকে না। প্রয়োজন হলে গন্তব্য গ্রুপে সেগুলি পুনরায় আপলোড করুন।",
+        "dropFileCospend": "একটি Cospend CSV ফাইল ড্রপ করুন, অথবা নির্বাচন করতে ক্লিক করুন",
+        "dropFileDescriptionCospend": "Cospend প্রতি প্রজেক্টে একটি CSV এক্সপোর্ট করে। আমরা সদস্য, প্রতিটি বিল এবং পুনরাবৃত্ত সময়সূচী আমদানি করি। এক্সপোর্টে উল্লেখ না থাকলে প্রজেক্টের বেস কারেন্সি ডিফল্টভাবে EUR হয় — পরবর্তী ধাপে এটি পরীক্ষা করুন।",
         "unsupportedFileType": "অসমর্থিত ফাইল টাইপ। অনুগ্রহ করে একটি JSON বা CSV ফাইল ড্রপ করুন।",
         "dropFileSplitwise": "একটি Splitwise CSV ফাইল ড্রপ করুন, অথবা নির্বাচন করতে ক্লিক করুন",
         "dropFileDescriptionSplitwise": "CSV হল Splitwise এক্সপোর্টের একমাত্র ফরম্যাট। আমরা বিভাজন পুনর্গঠন করতে প্রতি-অংশগ্রহণকারী মান পার্স করি।",

--- a/apps/web/src/messages/ca.json
+++ b/apps/web/src/messages/ca.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "DiDiària",
           "weekly": "Setmanal",
-          "monthly": "Mensual"
+          "monthly": "Mensual",
+          "yearly": "Anual"
         },
-        "documentCount": "Documents: {imported} recuperats, {skipped} omesos"
+        "documentCount": "Documents: {imported} recuperats, {skipped} omesos",
+        "recurrenceSchedule": {
+          "every": "Cada {interval} {frequency}",
+          "frequency": {
+            "daily": "dies",
+            "weekly": "setmanes",
+            "monthly": "mesos",
+            "yearly": "anys"
+          }
+        }
       },
       "Destination": {
         "heading": "On voleu importar <strong>{name}</strong>? ({participantCount} participants · {expenseCount} despeses)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (pròximament)",
         "settleUp": "Settle Up (pròximament)",
         "spliitDescription": "Porta un grup existent de spliit.app a Spliit Cloud. Llegim el nom del grup, els participants i cada despesa.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "Deixa caure un export CSV de Splitwise per importar les seves despeses a Spliit Cloud. El fitxer ha de provenir de l'exportació de grup de Splitwise — el CSV per grup disponible des dels paràmetres del grup.",
         "receiptWarningTitleSplitwise": "Les imatges dels rebuts no s'importen.",
         "receiptWarningDescriptionSplitwise": "L'exportació de Splitwise no inclou imatges dels rebuts. Torneu a pujar-les al grup de destí si les necessiteu.",
+        "cospendDescription": "Deixa caure un export CSV de Cospend per importar els seus membres, factures i calendaris recurrents a Spliit Cloud. Exporta el projecte des dels paràmetres de Cospend (un CSV per projecte). Les factures recurrents mantenen el seu calendari — s'admeten repeticions anuals, de múltiples intervals i amb data de finalització.",
+        "receiptWarningTitleCospend": "Les imatges de rebuts no s'importen.",
+        "receiptWarningDescriptionCospend": "L'exportació de Cospend no inclou imatges de rebuts. Torna a carregar-les al grup de destinació si les necessites.",
+        "dropFileCospend": "Deixa anar un fitxer CSV de Cospend, o fes clic per seleccionar",
+        "dropFileDescriptionCospend": "Cospend exporta un fitxer CSV per projecte. Importem els membres, cada factura i els calendaris recurrents. La moneda base del projecte és per defecte EUR quan l'exportació no l'especifica — revisa-la al pas següent.",
         "unsupportedFileType": "Tipus de fitxer no admès. Deixa anar un fitxer JSON o CSV.",
         "dropFileSplitwise": "Deixa anar un fitxer CSV de Splitwise, o fes clic per seleccionar",
         "dropFileDescriptionSplitwise": "CSV és l'únic format que exporta Splitwise. Analitzem els valors per participant per reconstruir el repartiment.",

--- a/apps/web/src/messages/cs-CZ.json
+++ b/apps/web/src/messages/cs-CZ.json
@@ -338,9 +338,19 @@
         "recurrenceRule": {
           "daily": "Denně",
           "weekly": "Týdně",
-          "monthly": "Měsíčně"
+          "monthly": "Měsíčně",
+          "yearly": "Ročně"
         },
-        "documentCount": "Dokumenty: obnoveno {imported}, přeskočeno {skipped}"
+        "documentCount": "Dokumenty: obnoveno {imported}, přeskočeno {skipped}",
+        "recurrenceSchedule": {
+          "every": "Každé {interval} {frequency}",
+          "frequency": {
+            "daily": "dny",
+            "weekly": "týdny",
+            "monthly": "měsíce",
+            "yearly": "roky"
+          }
+        }
       },
       "Destination": {
         "heading": "Kam chcete importovat <strong>{name}</strong>? ({participantCount} účastníků · {expenseCount} výdajů)",
@@ -417,6 +427,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (již brzy)",
         "settleUp": "Settle Up (již brzy)",
         "spliitDescription": "Přeneste existující skupinu z spliit.app do Spliit Cloud. Načteme název skupiny, účastníky a každý výdaj.",
@@ -445,6 +456,11 @@
         "splitwiseDescription": "Přetáhněte CSV export ze Splitwise pro import jeho výdajů do Spliit Cloudu. Soubor musí pocházet ze skupinového exportu Splitwise — CSV pro konkrétní skupinu dostupného v nastavení skupiny.",
         "receiptWarningTitleSplitwise": "Obrázky účtenek se neimportují.",
         "receiptWarningDescriptionSplitwise": "Export ze Splitwise neobsahuje obrázky účtenek. V případě potřeby je nahrajte znovu do cílové skupiny.",
+        "cospendDescription": "Přetáhněte CSV export z Cospend pro import jeho členů, výdajů a opakujících se plánů do Spliit Cloudu. Exportujte projekt z nastavení Cospend (jeden soubor CSV na projekt). Opakující se výdaje si zachovají svůj plán — podporována jsou roční opakování, opakování s více intervaly i s datem ukončení.",
+        "receiptWarningTitleCospend": "Obrázky účtenek se neimportují.",
+        "receiptWarningDescriptionCospend": "Export Cospend neobsahuje obrázky účtenek. V případě potřeby je znovu nahrajte v cílové skupině.",
+        "dropFileCospend": "Přetáhněte CSV soubor Cospend, nebo kliknutím vyberte",
+        "dropFileDescriptionCospend": "Cospend exportuje jeden CSV soubor na projekt. Importujeme členy, každý výdaj i opakující se plány. Výchozí měnou projektu je EUR, pokud není v exportu uvedena — zkontrolujte ji v dalším kroku.",
         "unsupportedFileType": "Nepodporovaný typ souboru. Přetáhněte prosím soubor JSON nebo CSV.",
         "dropFileSplitwise": "Přetáhněte CSV soubor Splitwise, nebo kliknutím vyberte",
         "dropFileDescriptionSplitwise": "CSV je jediný formát, který Splitwise exportuje. Hodnoty za jednotlivé účastníky analyzujeme, abychom obnovili rozdělení.",

--- a/apps/web/src/messages/de-DE.json
+++ b/apps/web/src/messages/de-DE.json
@@ -345,9 +345,19 @@
         "recurrenceRule": {
           "daily": "Täglich",
           "weekly": "Wöchentlich",
-          "monthly": "Monatlich"
+          "monthly": "Monatlich",
+          "yearly": "Jährlich"
         },
-        "documentCount": "Dokumente: {imported} wiederhergestellt, {skipped} übersprungen"
+        "documentCount": "Dokumente: {imported} wiederhergestellt, {skipped} übersprungen",
+        "recurrenceSchedule": {
+          "every": "Alle {interval} {frequency}",
+          "frequency": {
+            "daily": "Tage",
+            "weekly": "Wochen",
+            "monthly": "Monate",
+            "yearly": "Jahre"
+          }
+        }
       },
       "Destination": {
         "heading": "Wohin möchtest du <strong>{name}</strong> importieren? ({participantCount} Teilnehmer · {expenseCount} Ausgaben)",
@@ -426,6 +436,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (demnächst)",
         "settleUp": "Settle Up (demnächst)",
         "spliitDescription": "Bringe eine bestehende spliit.app-Gruppe in Spliit Cloud. Wir lesen den Gruppennamen, die Teilnehmer und jede Ausgabe ein.",
@@ -454,6 +465,11 @@
         "splitwiseDescription": "Lege einen CSV-Export aus Splitwise ab, um dessen Ausgaben in Spliit Cloud zu importieren. Die Datei muss aus dem Gruppenexport von Splitwise stammen — die CSV pro Gruppe, die in den Gruppeneinstellungen verfügbar ist.",
         "receiptWarningTitleSplitwise": "Belegbilder werden nicht importiert.",
         "receiptWarningDescriptionSplitwise": "Der Splitwise-Export enthält keine Belegbilder. Lade sie bei Bedarf in der Zielgruppe erneut hoch.",
+        "cospendDescription": "Lege einen CSV-Export aus Cospend ab, um dessen Mitglieder, Rechnungen und wiederkehrenden Zeitpläne in Spliit Cloud zu importieren. Exportiere das Projekt aus den Einstellungen von Cospend (eine CSV pro Projekt). Wiederkehrende Rechnungen behalten ihren Zeitplan — jährliche Wiederholungen, Intervalle und Wiederholungs-Enddaten werden unterstützt.",
+        "receiptWarningTitleCospend": "Belegbilder werden nicht importiert.",
+        "receiptWarningDescriptionCospend": "Der Cospend-Export enthält keine Belegbilder. Lade sie bei Bedarf in der Zielgruppe erneut hoch.",
+        "dropFileCospend": "Lege einen Cospend-CSV-Export ab oder klicke zum Auswählen",
+        "dropFileDescriptionCospend": "Cospend exportiert eine CSV-Datei pro Projekt. Wir importieren die Mitglieder, jede Rechnung und wiederkehrende Zeitpläne. Die Basiswährung des Projekts wird standardmäßig auf EUR gesetzt, wenn sie nicht im Export angegeben ist — überprüfe dies im nächsten Schritt.",
         "unsupportedFileType": "Nicht unterstützter Dateityp. Bitte lege eine JSON- oder CSV-Datei ab.",
         "dropFileSplitwise": "Lege eine Splitwise-CSV-Datei ab oder klicke zum Auswählen",
         "dropFileDescriptionSplitwise": "CSV ist das einzige Format, das Splitwise exportiert. Wir analysieren die Beträge pro Teilnehmer, um die Aufteilung wiederherzustellen.",

--- a/apps/web/src/messages/en-GZ.json
+++ b/apps/web/src/messages/en-GZ.json
@@ -2078,9 +2078,19 @@
         "recurrenceRule": {
           "daily": "daily vibes",
           "weekly": "weekly vibes",
-          "monthly": "monthly vibes"
+          "monthly": "monthly vibes",
+          "yearly": "yearly vibes"
         },
-        "documentCount": "Docs: {imported} recovered, {skipped} skipped"
+        "documentCount": "Docs: {imported} recovered, {skipped} skipped",
+        "recurrenceSchedule": {
+          "every": "every {interval} {frequency}",
+          "frequency": {
+            "daily": "days, fr",
+            "weekly": "weeks, fr",
+            "monthly": "months, fr",
+            "yearly": "years, fr"
+          }
+        }
       },
       "CurrencyConversion": {
         "pairSection": "{source} → {target}, obviously",
@@ -2170,6 +2180,7 @@
       "Source": {
         "fromSpliit": "Spliit source",
         "splitwise": "Splitwise source",
+        "cospend": "Cospend",
         "tricount": "Tricount, coming soon",
         "settleUp": "Settle Up, coming soon",
         "spliitDescription": "bring an existing spliit.app group into Spliit Cloud. we read the group name, participants, and every expense.",
@@ -2198,6 +2209,11 @@
         "splitwiseDescription": "drop a Splitwise CSV export to import expenses into Spliit Cloud. it must come from the group's settings export.",
         "receiptWarningTitleSplitwise": "receipt images did not import.",
         "receiptWarningDescriptionSplitwise": "the Splitwise export has no receipt images. re-upload them in the destination group if needed.",
+        "cospendDescription": "drop a Cospend project CSV export to bring members, bills, and recurring schedules into Spliit Cloud. export it from Cospend settings (one CSV per project). recurring bills keep their schedule — yearly, multi-interval, and dated-end repeats are all supported.",
+        "receiptWarningTitleCospend": "receipt pics are not imported.",
+        "receiptWarningDescriptionCospend": "Cospend exports do not have receipt images. re-upload them in the group if you need them.",
+        "dropFileCospend": "drop a Cospend CSV export, or click to choose",
+        "dropFileDescriptionCospend": "Cospend exports one CSV per project. we pull in members, bills, and recurring schedules. base currency defaults to EUR if not in the export — check it in the next step.",
         "unsupportedFileType": "unsupported file type. drop a JSON or CSV file, please.",
         "dropFileSplitwise": "drop a Splitwise CSV file, or click to choose",
         "dropFileDescriptionSplitwise": "CSV is the only format Splitwise exports. we parse per-participant values to rebuild the split.",

--- a/apps/web/src/messages/en-US.json
+++ b/apps/web/src/messages/en-US.json
@@ -433,6 +433,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (coming soon)",
         "settleUp": "Settle Up (coming soon)",
         "spliitDescription": "Bring an existing spliit.app group into Spliit Cloud. We read the group name, participants, and every expense.",
@@ -461,6 +462,11 @@
         "splitwiseDescription": "Drop a Splitwise CSV export to import its expenses into Spliit Cloud. The file must come from Splitwise's group export — the per-group CSV available from the group's settings.",
         "receiptWarningTitleSplitwise": "Receipt images are not imported.",
         "receiptWarningDescriptionSplitwise": "The Splitwise export does not include receipt images. Re-upload them in the destination group if you need them.",
+        "cospendDescription": "Drop a Cospend project CSV export to import its members, bills, and recurring schedules into Spliit Cloud. Export the project from Cospend's settings (one CSV per project). Recurring bills keep their schedule — yearly, multi-interval, and dated-end repeats are all supported.",
+        "receiptWarningTitleCospend": "Receipt images are not imported.",
+        "receiptWarningDescriptionCospend": "The Cospend export does not include receipt images. Re-upload them in the destination group if you need them.",
+        "dropFileCospend": "Drop a Cospend CSV export, or click to select",
+        "dropFileDescriptionCospend": "Cospend exports one CSV per project. We import the members, every bill, and recurring schedules. The project's base currency defaults to EUR when the export doesn't state it — check it in the next step.",
         "unsupportedFileType": "Unsupported file type. Please drop a JSON or CSV file.",
         "dropFileSplitwise": "Drop a Splitwise CSV file, or click to select",
         "dropFileDescriptionSplitwise": "CSV is the only format Splitwise exports. We parse the per-participant values to reconstruct the split.",
@@ -583,7 +589,17 @@
         "recurrenceRule": {
           "daily": "Daily",
           "weekly": "Weekly",
-          "monthly": "Monthly"
+          "monthly": "Monthly",
+          "yearly": "Yearly"
+        },
+        "recurrenceSchedule": {
+          "every": "Every {interval} {frequency}",
+          "frequency": {
+            "daily": "day(s)",
+            "weekly": "week(s)",
+            "monthly": "month(s)",
+            "yearly": "year(s)"
+          }
         },
         "documentCount": "Documents: {imported} recovered, {skipped} skipped"
       },

--- a/apps/web/src/messages/en-US.json
+++ b/apps/web/src/messages/en-US.json
@@ -595,10 +595,10 @@
         "recurrenceSchedule": {
           "every": "Every {interval} {frequency}",
           "frequency": {
-            "daily": "day(s)",
-            "weekly": "week(s)",
-            "monthly": "month(s)",
-            "yearly": "year(s)"
+            "daily": "days",
+            "weekly": "weeks",
+            "monthly": "months",
+            "yearly": "years"
           }
         },
         "documentCount": "Documents: {imported} recovered, {skipped} skipped"

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -346,9 +346,19 @@
         "recurrenceRule": {
           "daily": "Diaria",
           "weekly": "Semanal",
-          "monthly": "Mensual"
+          "monthly": "Mensual",
+          "yearly": "Anual"
         },
-        "documentCount": "Documentos: {imported} recuperados, {skipped} omitidos"
+        "documentCount": "Documentos: {imported} recuperados, {skipped} omitidos",
+        "recurrenceSchedule": {
+          "every": "Cada {interval} {frequency}",
+          "frequency": {
+            "daily": "días",
+            "weekly": "semanas",
+            "monthly": "meses",
+            "yearly": "años"
+          }
+        }
       },
       "Destination": {
         "heading": "¿Dónde te gustaría importar <strong>{name}</strong>? ({participantCount} participantes · {expenseCount} gastos)",
@@ -427,6 +437,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (próximamente)",
         "settleUp": "Settle Up (próximamente)",
         "spliitDescription": "Trae un grupo existente de spliit.app a Spliit Cloud. Leemos el nombre del grupo, los participantes y cada gasto.",
@@ -455,6 +466,11 @@
         "splitwiseDescription": "Suelta una exportación CSV de Splitwise para importar sus gastos a Spliit Cloud. El archivo debe provenir de la exportación de grupo de Splitwise — el CSV por grupo disponible en los ajustes del grupo.",
         "receiptWarningTitleSplitwise": "Las imágenes de los recibos no se importan.",
         "receiptWarningDescriptionSplitwise": "La exportación de Splitwise no incluye imágenes de recibos. Vuelve a subirlas en el grupo de destino si las necesitas.",
+        "cospendDescription": "Suelta una exportación CSV de Cospend para importar sus miembros, facturas y calendarios recurrentes a Spliit Cloud. Exporta el proyecto desde los ajustes de Cospend (un CSV por proyecto). Las facturas recurrentes mantienen su calendario: se admiten repeticiones anuales, de múltiples intervalos y con fecha de finalización.",
+        "receiptWarningTitleCospend": "Las imágenes de los recibos no se importan.",
+        "receiptWarningDescriptionCospend": "La exportación de Cospend no incluye imágenes de recibos. Vuelve a subirlas en el grupo de destino si las necesitas.",
+        "dropFileCospend": "Arrastra un archivo CSV de Cospend, o haz clic para seleccionar",
+        "dropFileDescriptionCospend": "Cospend exporta un archivo CSV por proyecto. Importamos los miembros, cada factura y los calendarios recurrentes. La moneda base del proyecto se establece de forma predeterminada en EUR cuando la exportación no la indica; compruébala en el siguiente paso.",
         "unsupportedFileType": "Tipo de archivo no compatible. Arrastra un archivo JSON o CSV.",
         "dropFileSplitwise": "Arrastra un archivo CSV de Splitwise, o haz clic para seleccionar",
         "dropFileDescriptionSplitwise": "CSV es el único formato que exporta Splitwise. Analizamos los valores por participante para reconstruir el reparto.",

--- a/apps/web/src/messages/eu.json
+++ b/apps/web/src/messages/eu.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "Egunero",
           "weekly": "Astero",
-          "monthly": "Hilero"
+          "monthly": "Hilero",
+          "yearly": "Urtero"
         },
-        "documentCount": "Dokumentuak: {imported} berreskuratuta, {skipped} saltatuta"
+        "documentCount": "Dokumentuak: {imported} berreskuratuta, {skipped} saltatuta",
+        "recurrenceSchedule": {
+          "every": "{interval} {frequency}ero",
+          "frequency": {
+            "daily": "egun",
+            "weekly": "aste",
+            "monthly": "hilabete",
+            "yearly": "urte"
+          }
+        }
       },
       "Destination": {
         "heading": "Nora inportatu nahi duzu <strong>{name}</strong>? ({participantCount} parte-hartzaile · {expenseCount} gastu)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (laster)",
         "settleUp": "Settle Up (laster)",
         "spliitDescription": "Ekarri spliit.app-eko talde bat Spliit Cloud-era. Taldearen izena, parte-hartzaileak eta gastu guztiak irakurtzen ditugu.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "Jarein Splitwise-ko CSV esportazio bat bere gastuak Spliit Cloud-era inportatzeko. Fitxategia Splitwise-ko talde-esportaziotik etorri behar da — taldearen ezarpenetan eskuragarri dagoen taldeko CSV-a.",
         "receiptWarningTitleSplitwise": "Ordainagirien irudiak ez dira inportatzen.",
         "receiptWarningDescriptionSplitwise": "Splitwise-ko esportazioak ez ditu ordainagirien irudiak barne hartzen. Berriro igo itzazu helburuko taldean behar badituzu.",
+        "cospendDescription": "Jarein Cospend-eko CSV esportazio bat kideak, fakturak eta ordutegi errepikakorrak Spliit Cloud-era inportatzeko. Esportatu proiektua Cospend-en ezarpenetatik (proiektu bakoitzeko CSV bat). Faktura errepikakorrek euren ordutegia mantentzen dute — urtekoak, tarte anitzekoak eta amaiera-data dutenak onartzen dira.",
+        "receiptWarningTitleCospend": "Ordainagirien irudiak ez dira inportatzen.",
+        "receiptWarningDescriptionCospend": "Cospend-en esportazioak ez ditu ordainagirien irudiak biltzen. Berriz igo itzazu helburuko taldean, behar badituzu.",
+        "dropFileCospend": "Jaregin Cospend CSV fitxategi bat, edo egin klik hautatzeko",
+        "dropFileDescriptionCospend": "Cospend-ek proiektu bakoitzeko CSV fitxategi bat esportatzen du. Kideak, faktura guztiak eta ordutegi errepikakorrak inportatzen ditugu. Proiektuaren oinarrizko moneta EUR da lehenespenez esportazioan zehazten ez bada — egiaztatu hurrengo urratsean.",
         "unsupportedFileType": "Onartu gabeko fitxategi mota. Jaregin JSON edo CSV fitxategi bat.",
         "dropFileSplitwise": "Jaregin Splitwise CSV fitxategi bat, edo egin klik hautatzeko",
         "dropFileDescriptionSplitwise": "CSV da Splitwise-k esportatzen duen formatu bakarra. Parte-hartzaile bakoitzaren balioak aztertzen ditugu banaketa berreraikitzeko.",

--- a/apps/web/src/messages/fi.json
+++ b/apps/web/src/messages/fi.json
@@ -330,9 +330,19 @@
         "recurrenceRule": {
           "daily": "PPäivittäin",
           "weekly": "Viikoittain",
-          "monthly": "Kuukausittain"
+          "monthly": "Kuukausittain",
+          "yearly": "Vuosittain"
         },
-        "documentCount": "Asiakirjat: {imported} palautettu, {skipped} ohitettu"
+        "documentCount": "Asiakirjat: {imported} palautettu, {skipped} ohitettu",
+        "recurrenceSchedule": {
+          "every": "Joka {interval}. {frequency}",
+          "frequency": {
+            "daily": "päivä",
+            "weekly": "viikko",
+            "monthly": "kuukausi",
+            "yearly": "vuosi"
+          }
+        }
       },
       "Destination": {
         "heading": "Mihin haluat tuoda <strong>{name}</strong>? ({participantCount} osallistujaa · {expenseCount} kulua)",
@@ -407,6 +417,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (tulossa pian)",
         "settleUp": "Settle Up (tulossa pian)",
         "spliitDescription": "Tuo olemassa oleva spliit.app-ryhmä Spliit Cloudiin. Luemme ryhmän nimen, osallistujat ja kaikki kulut.",
@@ -435,6 +446,11 @@
         "splitwiseDescription": "Pudota Splitwise CSV-vienti tuodaksesi sen kulut Spliit Cloudiin. Tiedoston on tultava Splitwisen ryhmäviennistä — ryhmäkohtainen CSV, joka on saatavilla ryhmän asetuksista.",
         "receiptWarningTitleSplitwise": "Kuittikuvia ei tuoda.",
         "receiptWarningDescriptionSplitwise": "Splitwise-vienti ei sisällä kuittikuvia. Lataa ne uudelleen kohderyhmään, jos tarvitset niitä.",
+        "cospendDescription": "Pudota Cospend-projektin CSV-vienti tuodaksesi sen jäsenet, laskut ja toistuvat aikataulut Spliit Cloudiin. Vie projekti Cospendin asetuksista (yksi CSV projektia kohden). Toistuvat laskut säilyttävät aikataulunsa — vuosittaiset, usean jakson ja päättymispäivämäärän toistot ovat tuettuja.",
+        "receiptWarningTitleCospend": "Kuittikuvia ei tuoda.",
+        "receiptWarningDescriptionCospend": "Cospend-vienti ei sisällä kuittikuvia. Lataa ne uudelleen kohderyhmään, jos tarvitset niitä.",
+        "dropFileCospend": "Pudota Cospend CSV -vienti tai napsauta valitaksesi",
+        "dropFileDescriptionCospend": "Cospend vie yhden CSV-tiedoston projektia kohden. Tuomme jäsenet, kaikki laskut ja toistuvat aikataulut. Projektin perusvaluutaksi asetetaan oletuksena EUR, jos sitä ei ole ilmoitettu viennissä — tarkista se seuraavassa vaiheessa.",
         "unsupportedFileType": "Ei tuettu tiedostotyyppi. Pudota JSON- tai CSV-tiedosto.",
         "dropFileSplitwise": "Pudota Splitwise CSV -tiedosto tai napsauta valitaksesi",
         "dropFileDescriptionSplitwise": "CSV on ainoa muoto, jonka Splitwise vie. Jäsentelemme osallistujakohtaiset arvot jaon rekonstruoimiseksi.",

--- a/apps/web/src/messages/fr-FR.json
+++ b/apps/web/src/messages/fr-FR.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "Quotidienne",
           "weekly": "Hebdomadaire",
-          "monthly": "Mensuelle"
+          "monthly": "Mensuelle",
+          "yearly": "Annuelle"
         },
-        "documentCount": "Documents : {imported} récupérés, {skipped} ignorés"
+        "documentCount": "Documents : {imported} récupérés, {skipped} ignorés",
+        "recurrenceSchedule": {
+          "every": "Tous les {interval} {frequency}",
+          "frequency": {
+            "daily": "jours",
+            "weekly": "semaines",
+            "monthly": "mois",
+            "yearly": "ans"
+          }
+        }
       },
       "Destination": {
         "heading": "Où souhaitez-vous importer <strong>{name}</strong>? ({participantCount} participants · {expenseCount} dépenses)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (à venir)",
         "settleUp": "Settle Up (à venir)",
         "spliitDescription": "Importez un groupe spliit.app existant dans Spliit Cloud. Nous lisons le nom du groupe, les participants et chaque dépense.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "Déposez un export CSV de Splitwise pour importer ses dépenses dans Spliit Cloud. Le fichier doit provenir de l'export de groupe de Splitwise — le CSV par groupe disponible dans les paramètres du groupe.",
         "receiptWarningTitleSplitwise": "Les images de reçus ne sont pas importées.",
         "receiptWarningDescriptionSplitwise": "L'export Splitwise n'inclut pas les images de reçus. Réimportez-les dans le groupe de destination si nécessaire.",
+        "cospendDescription": "Déposez un export CSV de Cospend pour importer ses membres, factures et plannings récurrents dans Spliit Cloud. Exportez le projet depuis les paramètres de Cospend (un CSV par projet). Les factures récurrentes conservent leur planning — les répétitions annuelles, multi-intervalles et avec date de fin sont prises en charge.",
+        "receiptWarningTitleCospend": "Les images de reçus ne sont pas importées.",
+        "receiptWarningDescriptionCospend": "L'export Cospend n'inclut pas les images de reçus. Réimportez-les dans le groupe de destination si nécessaire.",
+        "dropFileCospend": "Déposez un fichier CSV Cospend, ou cliquez pour sélectionner",
+        "dropFileDescriptionCospend": "Cospend exporte un fichier CSV par projet. Nous importons les membres, chaque facture et les plannings récurrents. La devise de base du projet est définie par défaut sur EUR lorsque l'export ne l'indique pas — vérifiez-la à l'étape suivante.",
         "unsupportedFileType": "Type de fichier non pris en charge. Déposez un fichier JSON ou CSV.",
         "dropFileSplitwise": "Déposez un fichier CSV Splitwise, ou cliquez pour sélectionner",
         "dropFileDescriptionSplitwise": "CSV est le seul format exporté par Splitwise. Nous analysons les valeurs par participant pour reconstituer la répartition.",

--- a/apps/web/src/messages/he.json
+++ b/apps/web/src/messages/he.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "יומי",
           "weekly": "שבועי",
-          "monthly": "חודשי"
+          "monthly": "חודשי",
+          "yearly": "שנתי"
         },
-        "documentCount": "מסמכים: {imported} שוחזרו, {skipped} דולגו"
+        "documentCount": "מסמכים: {imported} שוחזרו, {skipped} דולגו",
+        "recurrenceSchedule": {
+          "every": "כל {interval} {frequency}",
+          "frequency": {
+            "daily": "ימים",
+            "weekly": "שבועות",
+            "monthly": "חודשים",
+            "yearly": "שנים"
+          }
+        }
       },
       "Destination": {
         "heading": "לאן תרצה לייבא את <strong>{name}</strong>? ({participantCount} משתתפים · {expenseCount} הוצאות)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (בקרוב)",
         "settleUp": "Settle Up (בקרוב)",
         "spliitDescription": "הבא קבוצה קיימת מ-spliit.app ל-Spliit Cloud. אנו קוראים את שם הקבוצה, המשתתפים וכל הוצאה.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "גרור קובץ CSV של ייצוא מ-Splitwise כדי לייבא את ההוצאות שלו ל-Spliit Cloud. הקובץ חייב להגיע מייצוא הקבוצה של Splitwise — ה-CSV לכל קבוצה הזמין בהגדרות הקבוצה.",
         "receiptWarningTitleSplitwise": "תמונות קבלות לא מיובאות.",
         "receiptWarningDescriptionSplitwise": "הייצוא של Splitwise אינו כולל תמונות קבלות. העלה אותן מחדש בקבוצת היעד אם אתה צריך אותן.",
+        "cospendDescription": "גרור קובץ CSV של ייצוא פרויקט מ-Cospend כדי לייבא את החברים, החשבונות ולוחות הזמנים החוזרים שלו ל-Spliit Cloud. ייצא את הפרויקט מהגדרות Cospend (קובץ CSV אחד לכל פרויקט). חשבונות חוזרים שומרים על לוח הזמנים שלהם — חזרות שנתיות, רב-מרווחיות ועם תאריך סיום נתמכות כולן.",
+        "receiptWarningTitleCospend": "תמונות קבלות אינן מיובאות.",
+        "receiptWarningDescriptionCospend": "ייצוא Cospend אינו כולל תמונות קבלות. העלה אותן מחדש בקבוצת היעד במידת הצורך.",
+        "dropFileCospend": "גרור קובץ CSV של Cospend, או לחץ לבחירה",
+        "dropFileDescriptionCospend": "Cospend מייצאת קובץ CSV אחד לכל פרויקט. אנו מייבאים את החברים, כל חשבון ולוחות זמנים חוזרים. מטבע הבסיס של הפרויקט מוגדר כברירת מחדל ל-EUR כאשר הייצוא אינו מציין זאת — בדוק זאת בשלב הבא.",
         "unsupportedFileType": "סוג קובץ לא נתמך. אנא גרור קובץ JSON או CSV.",
         "dropFileSplitwise": "גרור קובץ CSV של Splitwise, או לחץ לבחירה",
         "dropFileDescriptionSplitwise": "CSV הוא הפורמט היחיד ש-Splitwise מייצאת. אנו מנתחים את הערכים לכל משתתף כדי לשחזר את החלוקה.",

--- a/apps/web/src/messages/hi-IN.json
+++ b/apps/web/src/messages/hi-IN.json
@@ -1857,9 +1857,19 @@
         "recurrenceRule": {
           "daily": "दैनिक",
           "weekly": "साप्ताहिक",
-          "monthly": "मासिक"
+          "monthly": "मासिक",
+          "yearly": "वार्षिक"
         },
-        "documentCount": "दस्तावेज़: {imported} पुनर्प्राप्त किए गए, {skipped} छोड़ दिए गए"
+        "documentCount": "दस्तावेज़: {imported} पुनर्प्राप्त किए गए, {skipped} छोड़ दिए गए",
+        "recurrenceSchedule": {
+          "every": "हर {interval} {frequency}",
+          "frequency": {
+            "daily": "दिन",
+            "weekly": "सप्ताह",
+            "monthly": "महीने",
+            "yearly": "वर्ष"
+          }
+        }
       },
       "CurrencyConversion": {
         "pairSection": "{source} → {target}",
@@ -1949,6 +1959,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (जल्द आ रहा है)",
         "settleUp": "Settle Up (जल्द आ रहा है)",
         "spliitDescription": "मौजूदा spliit.app समूह को Spliit Cloud में लाएं। हम समूह का नाम, सदस्य और प्रत्येक खर्च पढ़ते हैं।",
@@ -1977,6 +1988,11 @@
         "splitwiseDescription": "Splitwise CSV निर्यात को Spliit Cloud में आयात करने के लिए छोड़ें। फ़ाइल Splitwise के समूह निर्यात से आनी चाहिए — समूह की सेटिंग से उपलब्ध प्रति-समूह CSV।",
         "receiptWarningTitleSplitwise": "रसीद छवियां आयात नहीं की गईं।",
         "receiptWarningDescriptionSplitwise": "Splitwise निर्यात में रसीद छवियां शामिल नहीं होतीं। यदि आवश्यक हों तो उन्हें गंतव्य समूह में पुनः अपलोड करें।",
+        "cospendDescription": "Cospend प्रोजेक्ट CSV निर्यात को Spliit Cloud में सदस्यों, बिलों और आवर्ती शेड्यूल को आयात करने के लिए छोड़ें। Cospend की सेटिंग से प्रोजेक्ट निर्यात करें (प्रति प्रोजेक्ट एक CSV)। आवर्ती बिल अपना शेड्यूल बनाए रखते हैं — वार्षिक, बहु-अंतराल और समाप्ति तिथि वाले दोहराव समर्थित हैं।",
+        "receiptWarningTitleCospend": "रसीद की छवियां आयात नहीं की जाती हैं।",
+        "receiptWarningDescriptionCospend": "Cospend निर्यात में रसीद की छवियां शामिल नहीं हैं। यदि आपको उनकी आवश्यकता है तो उन्हें गंतव्य समूह में फिर से अपलोड करें।",
+        "dropFileCospend": "Cospend CSV फ़ाइल छोड़ें, या चुनने के लिए क्लिक करें",
+        "dropFileDescriptionCospend": "Cospend प्रति प्रोजेक्ट एक CSV निर्यात करता है। हम सदस्यों, प्रत्येक बिल और आवर्ती शेड्यूल को आयात करते हैं। यदि निर्यात में नहीं बताया गया है तो प्रोजेक्ट की मूल मुद्रा डिफ़ॉल्ट रूप से EUR होती है — अगले चरण में इसकी जाँच करें।",
         "unsupportedFileType": "असमर्थित फ़ाइल प्रकार। कृपया JSON या CSV फ़ाइल छोड़ें।",
         "dropFileSplitwise": "Splitwise CSV फ़ाइल छोड़ें, या चुनने के लिए क्लिक करें",
         "dropFileDescriptionSplitwise": "CSV एकमात्र फ़ॉर्मेट है जो Splitwise निर्यात करता है। हम विभाजन को पुनर्निर्मित करने के लिए प्रति-सदस्य मानों को पार्स करते हैं।",

--- a/apps/web/src/messages/id.json
+++ b/apps/web/src/messages/id.json
@@ -326,9 +326,19 @@
         "recurrenceRule": {
           "daily": "Harian",
           "weekly": "Mingguan",
-          "monthly": "Bulanan"
+          "monthly": "Bulanan",
+          "yearly": "Tahunan"
         },
-        "documentCount": "Dokumen: {imported} dipulihkan, {skipped} dilewati"
+        "documentCount": "Dokumen: {imported} dipulihkan, {skipped} dilewati",
+        "recurrenceSchedule": {
+          "every": "Setiap {interval} {frequency}",
+          "frequency": {
+            "daily": "hari",
+            "weekly": "minggu",
+            "monthly": "bulan",
+            "yearly": "tahun"
+          }
+        }
       },
       "Destination": {
         "heading": "Di mana Anda ingin mengimpor <strong>{name}</strong>? ({participantCount} peserta · {expenseCount} pengeluaran)",
@@ -402,6 +412,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (segera hadir)",
         "settleUp": "Settle Up (segera hadir)",
         "spliitDescription": "Bawa grup spliit.app yang ada ke Spliit Cloud. Kami membaca nama grup, peserta, dan setiap pengeluaran.",
@@ -430,6 +441,11 @@
         "splitwiseDescription": "Jatuhkan ekspor CSV Splitwise untuk mengimpor pengeluarannya ke Spliit Cloud. File harus berasal dari ekspor grup Splitwise — CSV per grup yang tersedia dari pengaturan grup.",
         "receiptWarningTitleSplitwise": "Gambar tanda terima tidak diimpor.",
         "receiptWarningDescriptionSplitwise": "Ekspor Splitwise tidak menyertakan gambar tanda terima. Unggah ulang di grup tujuan jika Anda membutuhkannya.",
+        "cospendDescription": "Jatuhkan ekspor CSV proyek Cospend untuk mengimpor anggota, tagihan, dan jadwal berulang ke Spliit Cloud. Ekspor proyek dari pengaturan Cospend (satu CSV per proyek). Tagihan berulang mempertahankan jadwalnya — pengulangan tahunan, multi-interval, dan dengan tanggal akhir semuanya didukung.",
+        "receiptWarningTitleCospend": "Gambar tanda terima tidak diimpor.",
+        "receiptWarningDescriptionCospend": "Ekspor Cospend tidak menyertakan gambar tanda terima. Unggah ulang di grup tujuan jika Anda membutuhkannya.",
+        "dropFileCospend": "Jatuhkan file CSV Cospend, atau klik untuk memilih",
+        "dropFileDescriptionCospend": "Cospend mengekspor satu CSV per proyek. Kami mengimpor anggota, setiap tagihan, dan jadwal berulang. Mata uang dasar proyek secara default adalah EUR jika tidak dinyatakan dalam ekspor — periksa pada langkah berikutnya.",
         "unsupportedFileType": "Jenis file tidak didukung. Jatuhkan file JSON atau CSV.",
         "dropFileSplitwise": "Jatuhkan file CSV Splitwise, atau klik untuk memilih",
         "dropFileDescriptionSplitwise": "CSV adalah satu-satunya format yang diekspor Splitwise. Kami mengurai nilai per peserta untuk menyusun ulang pembagian.",

--- a/apps/web/src/messages/it-IT.json
+++ b/apps/web/src/messages/it-IT.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "Giornaliera",
           "weekly": "Settimanale",
-          "monthly": "Mensile"
+          "monthly": "Mensile",
+          "yearly": "Annuale"
         },
-        "documentCount": "Documenti: {imported} recuperati, {skipped} ignorati"
+        "documentCount": "Documenti: {imported} recuperati, {skipped} ignorati",
+        "recurrenceSchedule": {
+          "every": "Ogni {interval} {frequency}",
+          "frequency": {
+            "daily": "giorni",
+            "weekly": "settimane",
+            "monthly": "mesi",
+            "yearly": "anni"
+          }
+        }
       },
       "Destination": {
         "heading": "Dove desideri importare <strong>{name}</strong>? ({participantCount} partecipanti · {expenseCount} spese)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (in arrivo)",
         "settleUp": "Settle Up (in arrivo)",
         "spliitDescription": "Porta un gruppo spliit.app esistente in Spliit Cloud. Leggiamo il nome del gruppo, i partecipanti e ogni spesa.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "Trascina un'esportazione CSV di Splitwise per importarne le spese in Spliit Cloud. Il file deve provenire dall'esportazione di gruppo di Splitwise — il CSV per gruppo disponibile nelle impostazioni del gruppo.",
         "receiptWarningTitleSplitwise": "Le immagini delle ricevute non vengono importate.",
         "receiptWarningDescriptionSplitwise": "L'esportazione di Splitwise non include le immagini delle ricevute. Ricaricale nel gruppo di destinazione se ti servono.",
+        "cospendDescription": "Trascina un'esportazione CSV di Cospend per importarne membri, fatture e scadenze ricorrenti in Spliit Cloud. Esporta il progetto dalle impostazioni di Cospend (un CSV per progetto). Le spese ricorrenti mantengono la loro pianificazione — sono supportate ripetizioni annuali, a intervalli multipli e con data di fine.",
+        "receiptWarningTitleCospend": "Le immagini delle ricevute non vengono importate.",
+        "receiptWarningDescriptionCospend": "L'esportazione di Cospend non include le immagini delle ricevute. Ricaricale nel gruppo di destinazione se ti servono.",
+        "dropFileCospend": "Trascina un file CSV di Cospend, o clicca per selezionare",
+        "dropFileDescriptionCospend": "Cospend esporta un file CSV per progetto. Importiamo i membri, ogni spesa e le scadenze ricorrenti. La valuta di base del progetto è impostata su EUR per impostazione predefinita se non indicata nell'esportazione — verificala nel passaggio successivo.",
         "unsupportedFileType": "Tipo di file non supportato. Trascina un file JSON o CSV.",
         "dropFileSplitwise": "Trascina un file CSV di Splitwise, o clicca per selezionare",
         "dropFileDescriptionSplitwise": "CSV è l'unico formato esportato da Splitwise. Analizziamo i valori per partecipante per ricostruire la divisione.",

--- a/apps/web/src/messages/ja-JP.json
+++ b/apps/web/src/messages/ja-JP.json
@@ -326,9 +326,19 @@
         "recurrenceRule": {
           "daily": "毎日",
           "weekly": "毎週",
-          "monthly": "毎月"
+          "monthly": "毎月",
+          "yearly": "毎年"
         },
-        "documentCount": "書類：{imported}件を復元済み、{skipped}件をスキップ"
+        "documentCount": "書類：{imported}件を復元済み、{skipped}件をスキップ",
+        "recurrenceSchedule": {
+          "every": "{interval} {frequency}ごと",
+          "frequency": {
+            "daily": "日",
+            "weekly": "週間",
+            "monthly": "か月",
+            "yearly": "年"
+          }
+        }
       },
       "Destination": {
         "heading": "<strong>{name}</strong> をどこにインポートしますか？（{participantCount} 名の参加者 · {expenseCount} 件の支出）",
@@ -402,6 +412,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise（近日対応予定）",
+        "cospend": "Cospend",
         "tricount": "Tricount（近日対応予定）",
         "settleUp": "Settle Up（近日対応予定）",
         "spliitDescription": "既存の spliit.app グループを Spliit Cloud に取り込みます。グループ名、参加者、すべての支出を読み取ります。",
@@ -430,6 +441,11 @@
         "splitwiseDescription": "Splitwise の CSV エクスポートをドロップして、その支出を Spliit Cloud に取り込みます。ファイルは Splitwise のグループエクスポート(グループ設定から取得できるグループ単位の CSV)から取得する必要があります。",
         "receiptWarningTitleSplitwise": "レシート画像はインポートされません。",
         "receiptWarningDescriptionSplitwise": "Splitwise のエクスポートにはレシート画像は含まれません。必要な場合は、宛先グループに再アップロードしてください。",
+        "cospendDescription": "Cospend のプロジェクト CSV エクスポートをドロップして、メンバー、請求、定期スケジュールを Spliit Cloud に取り込みます。Cospend の設定からプロジェクトをエクスポートしてください (プロジェクトごとに1つの CSV)。定期的な請求はスケジュールを維持します — 年次、複数間隔、終了日指定の繰り返しにすべて対応しています。",
+        "receiptWarningTitleCospend": "レシート画像はインポートされません。",
+        "receiptWarningDescriptionCospend": "Cospend のエクスポートにはレシート画像が含まれていません。必要な場合は移行先のグループで再アップロードしてください。",
+        "dropFileCospend": "Cospend の CSV ファイルをドロップするか、クリックして選択してください",
+        "dropFileDescriptionCospend": "Cospend はプロジェクトごとに1つの CSV をエクスポートします。メンバー、すべての請求、定期スケジュールを取り込みます。エクスポートに記載がない場合、プロジェクトの基本通貨はデフォルトで EUR になります。次のステップで確認してください。",
         "unsupportedFileType": "サポートされていないファイル形式です。JSON または CSV ファイルをドロップしてください。",
         "dropFileSplitwise": "Splitwise の CSV ファイルをドロップするか、クリックして選択してください",
         "dropFileDescriptionSplitwise": "CSV は Splitwise がエクスポートできる唯一の形式です。参加者ごとの値を解析して分割を再構成します。",

--- a/apps/web/src/messages/ko.json
+++ b/apps/web/src/messages/ko.json
@@ -248,9 +248,19 @@
         "recurrenceRule": {
           "daily": "매일",
           "weekly": "매주",
-          "monthly": "매월"
+          "monthly": "매월",
+          "yearly": "매년"
         },
-        "documentCount": "문서: {imported}개 복구됨, {skipped}개 건너뜀"
+        "documentCount": "문서: {imported}개 복구됨, {skipped}개 건너뜀",
+        "recurrenceSchedule": {
+          "every": "{interval}{frequency}마다",
+          "frequency": {
+            "daily": "일",
+            "weekly": "주",
+            "monthly": "개월",
+            "yearly": "년"
+          }
+        }
       },
       "Destination": {
         "heading": "<strong>{name}</strong>을(를) 어디로 가져오시겠습니까? ({participantCount}명의 참가자 · {expenseCount}개의 지출)",
@@ -329,6 +339,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (출시 예정)",
         "settleUp": "Settle Up (출시 예정)",
         "spliitDescription": "기존 spliit.app 그룹을 Spliit Cloud로 가져옵니다. 그룹 이름, 참가자 및 모든 지출을 읽어 들입니다.",
@@ -357,6 +368,11 @@
         "splitwiseDescription": "Splitwise CSV 내보내기를 드롭하여 해당 지출을 Spliit Cloud로 가져옵니다. 파일은 Splitwise의 그룹 내보내기에서 가져와야 합니다. 그룹 설정에서 사용할 수 있는 그룹별 CSV입니다.",
         "receiptWarningTitleSplitwise": "영수증 이미지는 가져오지 않습니다.",
         "receiptWarningDescriptionSplitwise": "Splitwise 내보내기에는 영수증 이미지가 포함되지 않습니다. 필요한 경우 대상 그룹에 다시 업로드하세요.",
+        "cospendDescription": "Cospend 프로젝트 CSV 내보내기를 드롭하여 멤버, 지출 내역 및 반복 일정을 Spliit Cloud로 가져옵니다. Cospend 설정에서 프로젝트를 내보내세요(프로젝트당 하나의 CSV). 반복 지출은 일정을 유지합니다. 연간, 다중 간격 및 종료일 지정 반복이 모두 지원됩니다.",
+        "receiptWarningTitleCospend": "영수증 이미지는 가져오지 않습니다.",
+        "receiptWarningDescriptionCospend": "Cospend 내보내기에는 영수증 이미지가 포함되지 않습니다. 필요한 경우 대상 그룹에 다시 업로드하세요.",
+        "dropFileCospend": "Cospend CSV 파일을 드롭하거나 클릭하여 선택하세요",
+        "dropFileDescriptionCospend": "Cospend는 프로젝트당 하나의 CSV를 내보냅니다. 멤버, 모든 지출 및 반복 일정을 가져옵니다. 내보내기에 명시되지 않은 경우 프로젝트 기본 통화는 EUR로 기본 설정됩니다. 다음 단계에서 확인하세요.",
         "unsupportedFileType": "지원하지 않는 파일 형식입니다. JSON 또는 CSV 파일을 드롭해 주세요.",
         "dropFileSplitwise": "Splitwise CSV 파일을 드롭하거나 클릭하여 선택하세요",
         "dropFileDescriptionSplitwise": "CSV는 Splitwise가 내보낼 수 있는 유일한 형식입니다. 참가자별 값을 분석하여 분담을 재구성합니다.",

--- a/apps/web/src/messages/mk-MK.json
+++ b/apps/web/src/messages/mk-MK.json
@@ -322,6 +322,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (наскоро)",
         "settleUp": "Settle Up (наскоро)",
         "spliitDescription": "Донесете постоечка spliit.app група во Spliit Cloud. Ги читаме името на групата, учесниците и сите трошоци.",
@@ -350,6 +351,11 @@
         "splitwiseDescription": "Пуштете CSV извоз од Splitwise за да ги увезете неговите трошоци во Spliit Cloud. Датотеката мора да доаѓа од групниот извоз на Splitwise — групниот CSV достапен од поставките на групата.",
         "receiptWarningTitleSplitwise": "Сликите од сметки не се увезуваат.",
         "receiptWarningDescriptionSplitwise": "Извозот од Splitwise не вклучува слики од сметки. Повторно поставете ги во групата-дестинација ако ви требаат.",
+        "cospendDescription": "Пуштете CSV извоз од Cospend за да ги увезете неговите членови, сметки и повторливи распореди во Spliit Cloud. Извезете го проектот од поставките на Cospend (еден CSV по проект). Повторливите сметки го задржуваат својот распоред — поддржани се годишни повторувања, повторувања со повеќе интервали и со краен датум.",
+        "receiptWarningTitleCospend": "Сликите од сметките не се увезуваат.",
+        "receiptWarningDescriptionCospend": "Извозот на Cospend не вклучува слики од сметки. Повторно прикачете ги во целната група доколку ви се потребни.",
+        "dropFileCospend": "Пуштете CSV датотека од Cospend, или кликнете за да изберете",
+        "dropFileDescriptionCospend": "Cospend извезува една CSV датотека по проект. Ги увезуваме членовите, секоја сметка и повторливите распореди. Основната валута на проектот стандардно е EUR кога не е наведена во извозот — проверете ја во следниот чекор.",
         "unsupportedFileType": "Неподдржан тип на датотека. Пуштете JSON или CSV датотека.",
         "dropFileSplitwise": "Пуштете CSV датотека од Splitwise, или кликнете за да изберете",
         "dropFileDescriptionSplitwise": "CSV е единствениот формат што Splitwise го извезува. Ги анализираме вредностите по учесник за да ја обновиме распределбата.",
@@ -460,9 +466,19 @@
         "recurrenceRule": {
           "daily": "Дневно",
           "weekly": "Неделно",
-          "monthly": "Месечно"
+          "monthly": "Месечно",
+          "yearly": "Годишно"
         },
-        "documentCount": "Документи: {imported} обновени, {skipped} прескокнати"
+        "documentCount": "Документи: {imported} обновени, {skipped} прескокнати",
+        "recurrenceSchedule": {
+          "every": "Секои {interval} {frequency}",
+          "frequency": {
+            "daily": "дена",
+            "weekly": "недели",
+            "monthly": "месеци",
+            "yearly": "години"
+          }
+        }
       },
       "Done": {
         "importComplete": "Увозот е завршен",

--- a/apps/web/src/messages/nl-NL.json
+++ b/apps/web/src/messages/nl-NL.json
@@ -346,9 +346,19 @@
         "recurrenceRule": {
           "daily": "Dagelijks",
           "weekly": "Wekelijks",
-          "monthly": "Maandelijks"
+          "monthly": "Maandelijks",
+          "yearly": "Jaarlijks"
         },
-        "documentCount": "Documenten: {imported} hersteld, {skipped} overgeslagen"
+        "documentCount": "Documenten: {imported} hersteld, {skipped} overgeslagen",
+        "recurrenceSchedule": {
+          "every": "Elke {interval} {frequency}",
+          "frequency": {
+            "daily": "dagen",
+            "weekly": "weken",
+            "monthly": "maanden",
+            "yearly": "jaren"
+          }
+        }
       },
       "Destination": {
         "heading": "Waar wil je <strong>{name}</strong> importeren? ({participantCount} deelnemers · {expenseCount} uitgaven)",
@@ -427,6 +437,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (binnenkort)",
         "settleUp": "Settle Up (binnenkort)",
         "spliitDescription": "Breng een bestaande spliit.app-groep naar Spliit Cloud. We lezen de groepsnaam, deelnemers en elke uitgave.",
@@ -455,6 +466,11 @@
         "splitwiseDescription": "Sleep een Splitwise CSV-export hierheen om de uitgaven ervan te importeren in Spliit Cloud. Het bestand moet afkomstig zijn van de groepsexport van Splitwise — de CSV per groep die beschikbaar is in de groepsinstellingen.",
         "receiptWarningTitleSplitwise": "Bonafbeeldingen worden niet geïmporteerd.",
         "receiptWarningDescriptionSplitwise": "De Splitwise-export bevat geen bonafbeeldingen. Upload ze opnieuw in de doelgroep als je ze nodig hebt.",
+        "cospendDescription": "Sleep een Cospend-project CSV-export hierheen om leden, rekeningen en terugkerende schema's te importeren in Spliit Cloud. Exporteer het project vanuit de Cospend-instellingen (één CSV per project). Terugkerende rekeningen behouden hun schema — jaarlijkse, meerdelige intervallen en herhalingen met einddatum worden ondersteund.",
+        "receiptWarningTitleCospend": "Bonafbeeldingen worden niet geïmporteerd.",
+        "receiptWarningDescriptionCospend": "De Cospend-export bevat geen bonafbeeldingen. Upload ze opnieuw in de doelgroep als je ze nodig hebt.",
+        "dropFileCospend": "Sleep een Cospend CSV-export hierheen, of klik om te selecteren",
+        "dropFileDescriptionCospend": "Cospend exporteert één CSV per project. We importeren de leden, elke rekening en terugkerende schema's. De basisvaluta van het project staat standaard op EUR als deze niet in de export staat — controleer dit in de volgende stap.",
         "unsupportedFileType": "Niet-ondersteund bestandstype. Sleep een JSON- of CSV-bestand.",
         "dropFileSplitwise": "Sleep een Splitwise CSV-bestand, of klik om te selecteren",
         "dropFileDescriptionSplitwise": "CSV is het enige formaat dat Splitwise exporteert. We ontleden de waarden per deelnemer om de verdeling te reconstrueren.",

--- a/apps/web/src/messages/pl-PL.json
+++ b/apps/web/src/messages/pl-PL.json
@@ -338,9 +338,19 @@
         "recurrenceRule": {
           "daily": "Codziennie",
           "weekly": "Co tydzień",
-          "monthly": "Co miesiąc"
+          "monthly": "Co miesiąc",
+          "yearly": "Co rok"
         },
-        "documentCount": "Dokumenty: odzyskano {imported}, pominięto {skipped}"
+        "documentCount": "Dokumenty: odzyskano {imported}, pominięto {skipped}",
+        "recurrenceSchedule": {
+          "every": "Co {interval} {frequency}",
+          "frequency": {
+            "daily": "dni",
+            "weekly": "tygodnie",
+            "monthly": "miesiące",
+            "yearly": "lata"
+          }
+        }
       },
       "Destination": {
         "heading": "Gdzie chcesz zaimportować <strong>{name}</strong>? ({participantCount} uczestników · {expenseCount} wydatków)",
@@ -417,6 +427,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (wkrótce)",
         "settleUp": "Settle Up (wkrótce)",
         "spliitDescription": "Przenieś istniejącą grupę z spliit.app do Spliit Cloud. Odczytujemy nazwę grupy, uczestników i każdy wydatek.",
@@ -445,6 +456,11 @@
         "splitwiseDescription": "Upuść eksport CSV z Splitwise, aby zaimportować jego wydatki do Spliit Cloud. Plik musi pochodzić z eksportu grupy Splitwise — CSV dla konkretnej grupy dostępnego w ustawieniach grupy.",
         "receiptWarningTitleSplitwise": "Obrazy paragonów nie są importowane.",
         "receiptWarningDescriptionSplitwise": "Eksport Splitwise nie zawiera obrazów paragonów. Prześlij je ponownie w grupie docelowej, jeśli ich potrzebujesz.",
+        "cospendDescription": "Upuść eksport CSV z Cospend, aby zaimportować jego członków, rachunki i harmonogramy cykliczne do Spliit Cloud. Wyeksportuj projekt z ustawień Cospend (jeden plik CSV na projekt). Rachunki cykliczne zachowują swój harmonogram — obsługiwane są powtórzenia roczne, o wielu interwałach oraz z datą końcową.",
+        "receiptWarningTitleCospend": "Zdjęcia paragonów nie są importowane.",
+        "receiptWarningDescriptionCospend": "Eksport Cospend nie zawiera zdjęć paragonów. Prześlij je ponownie w grupie docelowej, jeśli ich potrzebujesz.",
+        "dropFileCospend": "Upuść plik CSV z Cospend lub kliknij, aby wybrać",
+        "dropFileDescriptionCospend": "Cospend eksportuje jeden plik CSV na projekt. Importujemy członków, każdy rachunek i harmonogramy cykliczne. Waluta bazowa projektu to domyślnie EUR, jeśli nie podano jej w eksporcie — sprawdź ją w następnym kroku.",
         "unsupportedFileType": "Nieobsługiwany typ pliku. Upuść plik JSON lub CSV.",
         "dropFileSplitwise": "Upuść plik CSV z Splitwise lub kliknij, aby wybrać",
         "dropFileDescriptionSplitwise": "CSV to jedyny format, jaki eksportuje Splitwise. Analizujemy wartości na uczestnika, aby odtworzyć podział.",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "Diária",
           "weekly": "Semanal",
-          "monthly": "Mensal"
+          "monthly": "Mensal",
+          "yearly": "Anual"
         },
-        "documentCount": "Documentos: {imported} recuperados, {skipped} ignorados"
+        "documentCount": "Documentos: {imported} recuperados, {skipped} ignorados",
+        "recurrenceSchedule": {
+          "every": "A cada {interval} {frequency}",
+          "frequency": {
+            "daily": "dias",
+            "weekly": "semanas",
+            "monthly": "meses",
+            "yearly": "anos"
+          }
+        }
       },
       "Destination": {
         "heading": "Onde você gostaria de importar <strong>{name}</strong>? ({participantCount} participantes · {expenseCount} despesas)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (em breve)",
         "settleUp": "Settle Up (em breve)",
         "spliitDescription": "Traga um grupo existente do spliit.app para o Spliit Cloud. Lemos o nome do grupo, participantes e cada despesa.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "Solte um arquivo CSV exportado do Splitwise para importar suas despesas no Spliit Cloud. O arquivo deve vir da exportação de grupo do Splitwise — o CSV por grupo disponível nas configurações do grupo.",
         "receiptWarningTitleSplitwise": "As imagens de recibos não são importadas.",
         "receiptWarningDescriptionSplitwise": "A exportação do Splitwise não inclui imagens de recibos. Refaça o upload no grupo de destino se precisar delas.",
+        "cospendDescription": "Solte um arquivo CSV exportado do Cospend para importar seus membros, despesas e programações recorrentes no Spliit Cloud. Exporte o projeto a partir das configurações do Cospend (um CSV por projeto). As despesas recorrentes mantêm seu cronograma — repetições anuais, de múltiplos intervalos e com data de término são todas suportadas.",
+        "receiptWarningTitleCospend": "As imagens de recibos não são importadas.",
+        "receiptWarningDescriptionCospend": "A exportação do Cospend não inclui imagens de recibos. Envie-as novamente no grupo de destino se precisar delas.",
+        "dropFileCospend": "Solte um arquivo CSV do Cospend, ou clique para selecionar",
+        "dropFileDescriptionCospend": "O Cospend exporta um CSV por projeto. Importamos os membros, cada despesa e as programações recorrentes. A moeda base do projeto é padronizada como EUR caso a exportação não a defina — confirme-a no próximo passo.",
         "unsupportedFileType": "Tipo de arquivo não suportado. Solte um arquivo JSON ou CSV.",
         "dropFileSplitwise": "Solte um arquivo CSV do Splitwise, ou clique para selecionar",
         "dropFileDescriptionSplitwise": "CSV é o único formato que o Splitwise exporta. Analisamos os valores por participante para reconstruir a divisão.",

--- a/apps/web/src/messages/pt.json
+++ b/apps/web/src/messages/pt.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "Diária",
           "weekly": "Semanal",
-          "monthly": "Mensal"
+          "monthly": "Mensal",
+          "yearly": "Anual"
         },
-        "documentCount": "Documentos: {imported} recuperados, {skipped} ignorados"
+        "documentCount": "Documentos: {imported} recuperados, {skipped} ignorados",
+        "recurrenceSchedule": {
+          "every": "A cada {interval} {frequency}",
+          "frequency": {
+            "daily": "dias",
+            "weekly": "semanas",
+            "monthly": "meses",
+            "yearly": "anos"
+          }
+        }
       },
       "Destination": {
         "heading": "Onde gostaria de importar o <strong>{name}</strong>? ({participantCount} participantes · {expenseCount} despesas)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (em breve)",
         "settleUp": "Settle Up (em breve)",
         "spliitDescription": "Traga um grupo existente do spliit.app para o Spliit Cloud. Lemos o nome do grupo, participantes e cada despesa.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "Solte uma exportação CSV do Splitwise para importar as suas despesas para o Spliit Cloud. O ficheiro deve vir da exportação de grupo do Splitwise — o CSV por grupo disponível nas definições do grupo.",
         "receiptWarningTitleSplitwise": "As imagens de recibos não são importadas.",
         "receiptWarningDescriptionSplitwise": "A exportação do Splitwise não inclui imagens de recibos. Refaça o upload no grupo de destino se precisar delas.",
+        "cospendDescription": "Solte uma exportação CSV do Cospend para importar os seus membros, despesas e agendamentos recorrentes para o Spliit Cloud. Exporte o projeto a partir das definições do Cospend (um CSV por projeto). As contas recorrentes mantêm o seu agendamento — repetições anuais, com múltiplos intervalos e com data de término são todas suportadas.",
+        "receiptWarningTitleCospend": "As imagens de recibos não são importadas.",
+        "receiptWarningDescriptionCospend": "A exportação do Cospend não inclui imagens de recibos. Volte a carregá-las no grupo de destino, se precisar delas.",
+        "dropFileCospend": "Largue um ficheiro CSV do Cospend, ou clique para selecionar",
+        "dropFileDescriptionCospend": "O Cospend exporta um ficheiro CSV por projeto. Importamos os membros, todas as contas e os agendamentos recorrentes. A moeda base do projeto é definida como EUR por predefinição quando a exportação não a indica — verifique-a no passo seguinte.",
         "unsupportedFileType": "Tipo de ficheiro não suportado. Largue um ficheiro JSON ou CSV.",
         "dropFileSplitwise": "Largue um ficheiro CSV do Splitwise, ou clique para selecionar",
         "dropFileDescriptionSplitwise": "O CSV é o único formato que o Splitwise exporta. Analisamos os valores por participante para reconstruir a divisão.",

--- a/apps/web/src/messages/ro.json
+++ b/apps/web/src/messages/ro.json
@@ -334,9 +334,19 @@
         "recurrenceRule": {
           "daily": "Zilnic",
           "weekly": "Săptămânal",
-          "monthly": "Lunar"
+          "monthly": "Lunar",
+          "yearly": "Anual"
         },
-        "documentCount": "Documente: {imported} recuperate, {skipped} omise"
+        "documentCount": "Documente: {imported} recuperate, {skipped} omise",
+        "recurrenceSchedule": {
+          "every": "La fiecare {interval} {frequency}",
+          "frequency": {
+            "daily": "zile",
+            "weekly": "săptămâni",
+            "monthly": "luni",
+            "yearly": "ani"
+          }
+        }
       },
       "Destination": {
         "heading": "Unde doriți să importați <strong>{name}</strong>? ({participantCount} participanți · {expenseCount} cheltuieli)",
@@ -412,6 +422,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (în curând)",
         "settleUp": "Settle Up (în curând)",
         "spliitDescription": "Aduceți un grup existent de pe spliit.app în Spliit Cloud. Citim numele grupului, participanții și fiecare cheltuială.",
@@ -440,6 +451,11 @@
         "splitwiseDescription": "Plasați un export CSV din Splitwise pentru a-i importa cheltuielile în Spliit Cloud. Fișierul trebuie să provină din exportul de grup al Splitwise — CSV-ul per grup disponibil din setările grupului.",
         "receiptWarningTitleSplitwise": "Imaginile chitanțelor nu sunt importate.",
         "receiptWarningDescriptionSplitwise": "Exportul Splitwise nu include imaginile chitanțelor. Reîncărcați-le în grupul de destinație dacă aveți nevoie de ele.",
+        "cospendDescription": "Plasați un export CSV din Cospend pentru a importa membrii, facturile și programele recurente în Spliit Cloud. Exportați proiectul din setările Cospend (un CSV per proiect). Facturile recurente își păstrează programul — repetările anuale, la intervale multiple și cu dată de sfârșit sunt acceptate.",
+        "receiptWarningTitleCospend": "Imaginile chitanțelor nu sunt importate.",
+        "receiptWarningDescriptionCospend": "Exportul Cospend nu include imagini ale chitanțelor. Reîncărcați-le în grupul de destinație dacă aveți nevoie de ele.",
+        "dropFileCospend": "Lăsați un fișier CSV Cospend, sau faceți clic pentru a selecta",
+        "dropFileDescriptionCospend": "Cospend exportă un fișier CSV per proiect. Importăm membrii, fiecare factură și programele recurente. Moneda de bază a proiectului este implicit EUR atunci când exportul nu o specifică — verificați-o în pasul următor.",
         "unsupportedFileType": "Tip de fișier neacceptat. Lăsați un fișier JSON sau CSV.",
         "dropFileSplitwise": "Lăsați un fișier CSV Splitwise, sau faceți clic pentru a selecta",
         "dropFileDescriptionSplitwise": "CSV este singurul format pe care îl exportă Splitwise. Analizăm valorile per participant pentru a reconstrui împărțirea.",

--- a/apps/web/src/messages/ru-RU.json
+++ b/apps/web/src/messages/ru-RU.json
@@ -338,9 +338,19 @@
         "recurrenceRule": {
           "daily": "Ежедневно",
           "weekly": "Еженедельно",
-          "monthly": "Ежемесячно"
+          "monthly": "Ежемесячно",
+          "yearly": "Ежегодно"
         },
-        "documentCount": "Документы: восстановлено — {imported}, пропущено — {skipped}"
+        "documentCount": "Документы: восстановлено — {imported}, пропущено — {skipped}",
+        "recurrenceSchedule": {
+          "every": "Каждые {interval} {frequency}",
+          "frequency": {
+            "daily": "дней",
+            "weekly": "недель",
+            "monthly": "месяцев",
+            "yearly": "лет"
+          }
+        }
       },
       "Destination": {
         "heading": "Куда вы хотите импортировать <strong>{name}</strong>? ({participantCount} участников · {expenseCount} трат)",
@@ -417,6 +427,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (скоро)",
         "settleUp": "Settle Up (скоро)",
         "spliitDescription": "Перенесите существующую группу из spliit.app в Spliit Cloud. Мы считываем название группы, участников и каждую трату.",
@@ -445,6 +456,11 @@
         "splitwiseDescription": "Перетащите CSV-экспорт из Splitwise, чтобы импортировать его расходы в Spliit Cloud. Файл должен быть получен из группового экспорта Splitwise — CSV для конкретной группы, доступный в настройках группы.",
         "receiptWarningTitleSplitwise": "Изображения чеков не импортируются.",
         "receiptWarningDescriptionSplitwise": "Экспорт Splitwise не включает изображения чеков. Повторно загрузите их в группу назначения, если они вам нужны.",
+        "cospendDescription": "Перетащите CSV-экспорт Cospend, чтобы импортировать участников, счета и повторяющиеся расписания в Spliit Cloud. Экспортируйте проект из настроек Cospend (один CSV на проект). Повторяющиеся счета сохраняют свое расписание — поддерживаются ежегодные повторения, повторения с несколькими интервалами и с датой окончания.",
+        "receiptWarningTitleCospend": "Изображения чеков не импортируются.",
+        "receiptWarningDescriptionCospend": "Экспорт Cospend не содержит изображений чеков. Загрузите их заново в целевой группе при необходимости.",
+        "dropFileCospend": "Перетащите CSV-файл Cospend или нажмите для выбора",
+        "dropFileDescriptionCospend": "Cospend экспортирует один CSV на проект. Мы импортируем участников, каждый счет и повторяющиеся расписания. Базовая валюта проекта по умолчанию EUR, если она не указана в экспорте — проверьте ее на следующем шаге.",
         "unsupportedFileType": "Неподдерживаемый тип файла. Перетащите файл JSON или CSV.",
         "dropFileSplitwise": "Перетащите CSV-файл Splitwise или нажмите для выбора",
         "dropFileDescriptionSplitwise": "CSV — единственный формат, который экспортирует Splitwise. Мы разбираем значения по участникам, чтобы восстановить разбивку.",

--- a/apps/web/src/messages/sv-SE.json
+++ b/apps/web/src/messages/sv-SE.json
@@ -1857,9 +1857,19 @@
         "recurrenceRule": {
           "daily": "Dagligen",
           "weekly": "Veckovis",
-          "monthly": "Månadsvis"
+          "monthly": "Månadsvis",
+          "yearly": "Årsvis"
         },
-        "documentCount": "Dokument: {imported} återställda, {skipped} överhoppade"
+        "documentCount": "Dokument: {imported} återställda, {skipped} överhoppade",
+        "recurrenceSchedule": {
+          "every": "Varje {interval} {frequency}",
+          "frequency": {
+            "daily": "dagar",
+            "weekly": "veckor",
+            "monthly": "månader",
+            "yearly": "år"
+          }
+        }
       },
       "CurrencyConversion": {
         "pairSection": "{source} → {target}",
@@ -1949,6 +1959,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (kommer snart)",
         "settleUp": "Settle Up (kommer snart)",
         "spliitDescription": "Ta in en befintlig spliit.app-grupp till Spliit Cloud. Vi läser gruppnamn, deltagare och varje utgift.",
@@ -1977,6 +1988,11 @@
         "splitwiseDescription": "Släpp en Splitwise CSV-export för att importera dess utgifter till Spliit Cloud. Filen måste komma från Splitwise groupexport — CSV:n per grupp som är tillgänglig från gruppens inställningar.",
         "receiptWarningTitleSplitwise": "Kvittobilder importeras inte.",
         "receiptWarningDescriptionSplitwise": "Splitwise-exporten innehåller inte kvittobilder. Ladda upp dem igen i destinationsgruppen om du behöver dem.",
+        "cospendDescription": "Släpp en Cospend-projekt CSV-export för att importera medlemmar, räkningar och återkommande scheman till Spliit Cloud. Exportera projektet från Cospends inställningar (en CSV per projekt). Återkommande räkningar behåller sitt schema — årliga, flerintervalls- och datumavslutade upprepningar stöds.",
+        "receiptWarningTitleCospend": "Kvittobilder importeras inte.",
+        "receiptWarningDescriptionCospend": "Cospend-exporten innehåller inga kvittobilder. Ladda upp dem igen i målgruppen om du behöver dem.",
+        "dropFileCospend": "Släpp en Cospend CSV-export, eller klicka för att välja",
+        "dropFileDescriptionCospend": "Cospend exporterar en CSV per projekt. Vi importerar medlemmar, varje räkning och återkommande scheman. Projektets basvaluta sätts som standard till EUR om den inte anges i exporten — kontrollera i nästa steg.",
         "unsupportedFileType": "Filtypen stöds inte. Släpp en JSON- eller CSV-fil.",
         "dropFileSplitwise": "Släpp en Splitwise CSV-fil, eller klicka för att välja",
         "dropFileDescriptionSplitwise": "CSV är det enda formatet Splitwise exporterar. Vi tolkar delta-deltagarvärdena för att återskapa fördelningen.",

--- a/apps/web/src/messages/tr-TR.json
+++ b/apps/web/src/messages/tr-TR.json
@@ -330,9 +330,19 @@
         "recurrenceRule": {
           "daily": "Günlük",
           "weekly": "Haftalık",
-          "monthly": "Aylık"
+          "monthly": "Aylık",
+          "yearly": "Yıllık"
         },
-        "documentCount": "Belgeler: {imported} geri yüklendi, {skipped} atlandı"
+        "documentCount": "Belgeler: {imported} geri yüklendi, {skipped} atlandı",
+        "recurrenceSchedule": {
+          "every": "Her {interval} {frequency}",
+          "frequency": {
+            "daily": "gün",
+            "weekly": "hafta",
+            "monthly": "ay",
+            "yearly": "yıl"
+          }
+        }
       },
       "Destination": {
         "heading": "<strong>{name}</strong> grubunu nereye içe aktarmak istersiniz? ({participantCount} katılımcı · {expenseCount} harcama)",
@@ -407,6 +417,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (çok yakında)",
         "settleUp": "Settle Up (çok yakında)",
         "spliitDescription": "Mevcut bir spliit.app grubunu Spliit Cloud'a taşıyın. Grup adını, katılımcıları ve her harcamayı okuyoruz.",
@@ -435,6 +446,11 @@
         "splitwiseDescription": "Splitwise'den bir CSV dışa aktarımı bırakarak harcamalarını Spliit Cloud'a aktarın. Dosya, Splitwise'in grup dışa aktarımından gelmelidir — grup ayarlarından erişilebilen gruba özel CSV.",
         "receiptWarningTitleSplitwise": "Makbuz görüntüleri içe aktarılmaz.",
         "receiptWarningDescriptionSplitwise": "Splitwise dışa aktarımı makbuz görüntülerini içermez. İhtiyacınız varsa bunları hedef grupta yeniden yükleyin.",
+        "cospendDescription": "Üyelerini, faturalarını ve yinelenen planlarını Spliit Cloud'a aktarmak için bir Cospend proje CSV dışa aktarımı bırakın. Projeyi Cospend ayarlarından dışa aktarın (proje başına bir CSV). Yinelenen faturalar planlarını korur — yıllık, çoklu aralıklı ve bitiş tarihli tekrarların tümü desteklenir.",
+        "receiptWarningTitleCospend": "Makbuz resimleri içe aktarılmaz.",
+        "receiptWarningDescriptionCospend": "Cospend dışa aktarımı makbuz resimlerini içermez. İhtiyacınız varsa hedef grupta bunları tekrar yükleyin.",
+        "dropFileCospend": "Bir Cospend CSV dosyası bırakın veya seçmek için tıklayın",
+        "dropFileDescriptionCospend": "Cospend proje başına bir CSV dışa aktarır. Üyeleri, her faturayı ve yinelenen planları içe aktarırız. Dışa aktarımda belirtilmediğinde projenin temel para birimi varsayılan olarak EUR'dur — sonraki adımda kontrol edin.",
         "unsupportedFileType": "Desteklenmeyen dosya türü. Lütfen bir JSON veya CSV dosyası bırakın.",
         "dropFileSplitwise": "Bir Splitwise CSV dosyası bırakın veya seçmek için tıklayın",
         "dropFileDescriptionSplitwise": "CSV, Splitwise'in dışa aktardığı tek formattır. Bölüşümü yeniden oluşturmak için katılımcı başına değerleri ayrıştırırız.",

--- a/apps/web/src/messages/uk-UA.json
+++ b/apps/web/src/messages/uk-UA.json
@@ -338,9 +338,19 @@
         "recurrenceRule": {
           "daily": "Щодня",
           "weekly": "Щотижня",
-          "monthly": "Щомісяця"
+          "monthly": "Щомісяця",
+          "yearly": "Щорічно"
         },
-        "documentCount": "Документи: відновлено — {imported}, пропущено — {skipped}"
+        "documentCount": "Документи: відновлено — {imported}, пропущено — {skipped}",
+        "recurrenceSchedule": {
+          "every": "Кожні {interval} {frequency}",
+          "frequency": {
+            "daily": "днів",
+            "weekly": "тижнів",
+            "monthly": "місяців",
+            "yearly": "років"
+          }
+        }
       },
       "Destination": {
         "heading": "Куди ви хочете імпортувати <strong>{name}</strong>? ({participantCount} учасників · {expenseCount} витрат)",
@@ -417,6 +427,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (незабаром)",
         "settleUp": "Settle Up (незабаром)",
         "spliitDescription": "Перенесіть існуючу групу з spliit.app до Spliit Cloud. Ми зчитуємо назву групи, учасників і кожну витрату.",
@@ -445,6 +456,11 @@
         "splitwiseDescription": "Перетягніть CSV-експорт із Splitwise, щоб імпортувати його витрати до Spliit Cloud. Файл має бути отриманий із групового експорту Splitwise — CSV для конкретної групи, доступний у налаштуваннях групи.",
         "receiptWarningTitleSplitwise": "Зображення чеків не імпортуються.",
         "receiptWarningDescriptionSplitwise": "Експорт Splitwise не включає зображення чеків. Повторно завантажте їх у групу призначення, якщо вони вам потрібні.",
+        "cospendDescription": "Перетягніть CSV-експорт Cospend, щоб імпортувати учасників, рахунки та повторювані розклади до Spliit Cloud. Експортуйте проект із налаштувань Cospend (один CSV на проект). Повторювані рахунки зберігають свій розклад — підтримуються щорічні повторення, повторення з кількома інтервалами та з кінцевою датою.",
+        "receiptWarningTitleCospend": "Зображення чеків не імпортуються.",
+        "receiptWarningDescriptionCospend": "Експорт Cospend не містить зображень чеків. Завантажте їх знову в цільовій групі, якщо вони вам потрібні.",
+        "dropFileCospend": "Перетягніть CSV-файл Cospend або натисніть, щоб вибрати",
+        "dropFileDescriptionCospend": "Cospend експортує один CSV на проект. Ми імпортуємо учасників, кожен рахунок і повторювані розклади. Базова валюта проекту за замовчуванням EUR, якщо вона не вказана в експорті — перевірте її на наступному кроці.",
         "unsupportedFileType": "Непідтримуваний тип файлу. Перетягніть файл JSON або CSV.",
         "dropFileSplitwise": "Перетягніть CSV-файл Splitwise або натисніть, щоб вибрати",
         "dropFileDescriptionSplitwise": "CSV — це єдиний формат, який експортує Splitwise. Ми аналізуємо значення для кожного учасника, щоб відновити розподіл.",

--- a/apps/web/src/messages/ur-PK.json
+++ b/apps/web/src/messages/ur-PK.json
@@ -1857,9 +1857,19 @@
         "recurrenceRule": {
           "daily": "روزانہ",
           "weekly": "ہفتہ وار",
-          "monthly": "ماہانہ"
+          "monthly": "ماہانہ",
+          "yearly": "سالانہ"
         },
-        "documentCount": "دستاویزات: {imported} بازیاب، {skipped} چھوڑ دی گئیں"
+        "documentCount": "دستاویزات: {imported} بازیاب، {skipped} چھوڑ دی گئیں",
+        "recurrenceSchedule": {
+          "every": "ہر {interval} {frequency}",
+          "frequency": {
+            "daily": "دن",
+            "weekly": "ہفتے",
+            "monthly": "مہینے",
+            "yearly": "سال"
+          }
+        }
       },
       "CurrencyConversion": {
         "pairSection": "{source} → {target}",
@@ -1949,6 +1959,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount (جلد آرہا ہے)",
         "settleUp": "Settle Up (جلد آرہا ہے)",
         "spliitDescription": "ایک موجودہ spliit.app گروپ کو Spliit Cloud میں لائیں۔ ہم گروپ کا نام، شرکاء، اور ہر خرچہ پڑھتے ہیں۔",
@@ -1977,6 +1988,11 @@
         "splitwiseDescription": "Splitwise CSV برآمد کو ڈراپ کریں تاکہ اس کے اخراجات Spliit Cloud میں درآمد کیے جا سکیں۔ فائل Splitwise کے گروپ برآمد سے آنا چاہیے — فی گروپ CSV جو گروپ کی ترتیبات سے دستیاب ہے۔",
         "receiptWarningTitleSplitwise": "رسید کی تصاویر درآمد نہیں کی جاتیں۔",
         "receiptWarningDescriptionSplitwise": "Splitwise برآمد میں رسید کی تصاویر شامل نہیں ہیں۔ اگر آپ کو ان کی ضرورت ہو تو منزل گروپ میں دوبارہ اپ لوڈ کریں۔",
+        "cospendDescription": "Cospend پروجیکٹ CSV برآمد کو Spliit Cloud میں اراکین، بلوں اور بار بار آنے والے نظام الاوقات کو درآمد کرنے کے لیے ڈراپ کریں۔ Cospend کی ترتیبات سے پروجیکٹ برآمد کریں (فی پروجیکٹ ایک CSV)۔ بار بار آنے والے بل اپنے شیڈول کو برقرار رکھتے ہیں — سالانہ، کثیر وقفہ، اور آخری تاریخ کے اعادے معاونت یافتہ ہیں۔",
+        "receiptWarningTitleCospend": "رسید کی تصاویر درآمد نہیں کی جاتی ہیں۔",
+        "receiptWarningDescriptionCospend": "Cospend برآمد میں رسید کی تصاویر شامل نہیں ہیں۔ اگر ضرورت ہو تو انہیں منزل کے گروپ میں دوبارہ اپ لوڈ کریں۔",
+        "dropFileCospend": "Cospend CSV فائل ڈراپ کریں، یا منتخب کرنے کے لیے کلک کریں",
+        "dropFileDescriptionCospend": "Cospend فی پروجیکٹ ایک CSV برآمد کرتا ہے۔ ہم اراکین، ہر بل، اور بار بار آنے والے نظام الاوقات کو درآمد کرتے ہیں۔ پروجیکٹ کی بنیادی کرنسی طے شدہ طور پر EUR ہے اگر برآمد میں نہیں بتایا گیا — اگلے مرحلے میں اس کی تصدیق کریں۔",
         "unsupportedFileType": "غیر معاون فائل کی قسم۔ براہ کرم JSON یا CSV فائل ڈراپ کریں۔",
         "dropFileSplitwise": "Splitwise CSV فائل ڈراپ کریں، یا منتخب کرنے کے لیے کلک کریں",
         "dropFileDescriptionSplitwise": "CSV واحد فارمیٹ ہے جو Splitwise برآمد کرتا ہے۔ ہم تقسیم کو دوبارہ تشکیل دینے کے لیے فی شریک اقدار کو پارس کرتے ہیں۔",

--- a/apps/web/src/messages/vi.json
+++ b/apps/web/src/messages/vi.json
@@ -433,6 +433,7 @@
       "Source": {
         "fromSpliit": "Từ Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount",
         "settleUp": "Settle Up",
         "spliitDescription": "Nhập từ URL Spliit.",
@@ -461,6 +462,11 @@
         "splitwiseDescription": "Nhập từ CSV Splitwise.",
         "receiptWarningTitleSplitwise": "Lưu ý biên lai",
         "receiptWarningDescriptionSplitwise": "Biên lai sẽ không được nhập.",
+        "cospendDescription": "Thả tệp xuất CSV dự án Cospend để nhập thành viên, hóa đơn và lịch lặp lại vào Spliit Cloud. Xuất dự án từ cài đặt của Cospend (một CSV cho mỗi dự án). Hóa đơn định kỳ giữ nguyên lịch trình — các lần lặp hàng năm, nhiều khoảng thời gian và có ngày kết thúc đều được hỗ trợ.",
+        "receiptWarningTitleCospend": "Hình ảnh biên lai không được nhập.",
+        "receiptWarningDescriptionCospend": "Tệp xuất Cospend không bao gồm hình ảnh biên lai. Hãy tải lại chúng lên nhóm đích nếu bạn cần.",
+        "dropFileCospend": "Thả tệp CSV Cospend hoặc nhấp để chọn",
+        "dropFileDescriptionCospend": "Cospend xuất một tệp CSV cho mỗi dự án. Chúng tôi nhập các thành viên, mọi hóa đơn và lịch định kỳ. Tiền tệ cơ sở của dự án mặc định là EUR khi tệp xuất không nêu rõ — hãy kiểm tra ở bước tiếp theo.",
         "unsupportedFileType": "Loại tệp không hỗ trợ.",
         "dropFileSplitwise": "Thả tệp Splitwise",
         "dropFileDescriptionSplitwise": "Kéo và thả CSV Splitwise.",
@@ -583,9 +589,19 @@
         "recurrenceRule": {
           "daily": "Hàng ngày",
           "weekly": "Hàng tuần",
-          "monthly": "Hàng tháng"
+          "monthly": "Hàng tháng",
+          "yearly": "Hàng năm"
         },
-        "documentCount": "Tài liệu: đã khôi phục {imported}, đã bỏ qua {skipped}"
+        "documentCount": "Tài liệu: đã khôi phục {imported}, đã bỏ qua {skipped}",
+        "recurrenceSchedule": {
+          "every": "Mỗi {interval} {frequency}",
+          "frequency": {
+            "daily": "ngày",
+            "weekly": "tuần",
+            "monthly": "tháng",
+            "yearly": "năm"
+          }
+        }
       },
       "Done": {
         "importComplete": "Nhập hoàn tất!",

--- a/apps/web/src/messages/zh-CN.json
+++ b/apps/web/src/messages/zh-CN.json
@@ -326,9 +326,19 @@
         "recurrenceRule": {
           "daily": "每天",
           "weekly": "每周",
-          "monthly": "每月"
+          "monthly": "每月",
+          "yearly": "每年"
         },
-        "documentCount": "文档：恢复 {imported} 份，跳过 {skipped} 份"
+        "documentCount": "文档：恢复 {imported} 份，跳过 {skipped} 份",
+        "recurrenceSchedule": {
+          "every": "每 {interval} {frequency}",
+          "frequency": {
+            "daily": "天",
+            "weekly": "周",
+            "monthly": "个月",
+            "yearly": "年"
+          }
+        }
       },
       "Destination": {
         "heading": "您想将 <strong>{name}</strong> 导入到哪里？（{participantCount} 名参与者 · {expenseCount} 笔支出）",
@@ -402,6 +412,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise",
+        "cospend": "Cospend",
         "tricount": "Tricount（即将推出）",
         "settleUp": "Settle Up（即将推出）",
         "spliitDescription": "将现有的 spliit.app 群组导入 Spliit Cloud。我们会读取群组名称、参与者和每笔支出。",
@@ -430,6 +441,11 @@
         "splitwiseDescription": "拖入 Splitwise 的 CSV 导出文件，将其支出导入 Spliit Cloud。文件必须来自 Splitwise 的群组导出（可在群组设置中获取的按群组的 CSV）。",
         "receiptWarningTitleSplitwise": "收据图片不会被导入。",
         "receiptWarningDescriptionSplitwise": "Splitwise 的导出不包含收据图片。如果需要，请在目标群组中重新上传。",
+        "cospendDescription": "拖入 Cospend 的 CSV 导出文件，将其成员、账单和周期性计划导入 Spliit Cloud。请从 Cospend 的设置中导出项目（每个项目一个 CSV）。周期性账单将保留其计划——支持年度、多间隔以及带有结束日期的重复。",
+        "receiptWarningTitleCospend": "不会导入收据图片。",
+        "receiptWarningDescriptionCospend": "Cospend 导出不包含收据图片。如有需要，请在目标群组中重新上传。",
+        "dropFileCospend": "拖放 Cospend CSV 文件，或点击选择",
+        "dropFileDescriptionCospend": "Cospend 为每个项目导出一个 CSV 文件。我们会导入成员、每笔账单和周期性计划。若导出中未注明项目基准货币，则默认为 EUR——请在下一步中核对。",
         "unsupportedFileType": "不支持的文件类型，请拖放 JSON 或 CSV 文件。",
         "dropFileSplitwise": "拖放 Splitwise CSV 文件，或点击选择",
         "dropFileDescriptionSplitwise": "CSV 是 Splitwise 唯一支持导出的格式。我们会解析每位参与者的金额来重建分摊。",

--- a/apps/web/src/messages/zh-TW.json
+++ b/apps/web/src/messages/zh-TW.json
@@ -326,9 +326,19 @@
         "recurrenceRule": {
           "daily": "每天",
           "weekly": "每週",
-          "monthly": "每月"
+          "monthly": "每月",
+          "yearly": "每年"
         },
-        "documentCount": "文件：已還原 {imported} 份，已略過 {skipped} 份"
+        "documentCount": "文件：已還原 {imported} 份，已略過 {skipped} 份",
+        "recurrenceSchedule": {
+          "every": "每 {interval} {frequency}",
+          "frequency": {
+            "daily": "天",
+            "weekly": "週",
+            "monthly": "個月",
+            "yearly": "年"
+          }
+        }
       },
       "Destination": {
         "heading": "您想要將 <strong>{name}</strong> 匯入到哪裡？（{participantCount} 位參與者 · {expenseCount} 筆支出）",
@@ -402,6 +412,7 @@
       "Source": {
         "fromSpliit": "Spliit",
         "splitwise": "Splitwise（即將推出）",
+        "cospend": "Cospend",
         "tricount": "Tricount（即將推出）",
         "settleUp": "Settle Up（即將推出）",
         "spliitDescription": "將現有的 spliit.app 群組帶入 Spliit Cloud。我們會讀取群組名稱、參與者和每筆支出。",
@@ -430,6 +441,11 @@
         "splitwiseDescription": "拖入 Splitwise 的 CSV 匯出檔案，將其支出匯入 Spliit Cloud。檔案必須來自 Splitwise 的群組匯出（可在群組設定中取得的按群組 CSV）。",
         "receiptWarningTitleSplitwise": "收據圖片不會被匯入。",
         "receiptWarningDescriptionSplitwise": "Splitwise 的匯出不包含收據圖片。如有需要，請在目的地群組中重新上傳。",
+        "cospendDescription": "拖入 Cospend 的 CSV 匯出檔案，將其成員、帳單和週期性排程匯入 Spliit Cloud。請從 Cospend 的設定中匯出專案（每個專案一個 CSV）。週期性帳單將保留其排程——支援年度、多間隔以及帶有結束日期的重複。",
+        "receiptWarningTitleCospend": "不會匯入收據圖片。",
+        "receiptWarningDescriptionCospend": "Cospend 匯出不包含收據圖片。如有需要，請在目標群組中重新上傳。",
+        "dropFileCospend": "拖放 Cospend CSV 檔案，或按一下以選取",
+        "dropFileDescriptionCospend": "Cospend 為每個專案匯出一個 CSV 檔案。我們會匯入成員、每筆帳單和週期性排程。若匯出中未註明專案基準貨幣，則預設為 EUR——請在下一步中核對。",
         "unsupportedFileType": "不支援的檔案類型，請拖放 JSON 或 CSV 檔案。",
         "dropFileSplitwise": "拖放 Splitwise CSV 檔案，或按一下以選取",
         "dropFileDescriptionSplitwise": "CSV 是 Splitwise 唯一匯出的格式。我們會解析每位參與者的金額來重建分攤。",

--- a/apps/web/src/router/schemas.ts
+++ b/apps/web/src/router/schemas.ts
@@ -55,7 +55,14 @@ const globalExpensesReturnTo = z
 export const importGroupSearchSchema = z.object({
   prefill: z.string().optional(),
   source: z
-    .enum(['spliit', 'spliit-cloud', 'splitwise', 'tricount', 'settleup'])
+    .enum([
+      'spliit',
+      'spliit-cloud',
+      'splitwise',
+      'cospend',
+      'tricount',
+      'settleup',
+    ])
     .optional(),
 })
 

--- a/packages/domain/src/import/cospend-categories.ts
+++ b/packages/domain/src/import/cospend-categories.ts
@@ -20,7 +20,6 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
       'grocer',
       'groceries',
       'supermarket',
-      'lebensmittel',
     ],
     'groceries',
   ],
@@ -56,22 +55,11 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
     ],
     'liquor',
   ],
-  [
-    [
-      'lebensmittel',
-      'food',
-      'essen',
-      'snack',
-      'imbiß',
-      'imbiss',
-      'verpflegung',
-    ],
-    'food-and-drink',
-  ],
+  [['food', 'snack', 'imbiß', 'verpflegung'], 'food-and-drink'],
   // Home
-  [['miete', 'rent', 'miete'], 'rent'],
-  [['strom', 'electricity', 'strom', 'energie', 'energy'], 'electricity'],
-  [['gas', 'heizung', 'heat', 'warme', 'wärme', 'gas'], 'heat-gas'],
+  [['miete', 'rent'], 'rent'],
+  [['strom', 'electricity', 'energie', 'energy'], 'electricity'],
+  [['gas', 'heizung', 'heat', 'warme', 'wärme'], 'heat-gas'],
   [['wasser', 'water'], 'water'],
   [
     ['internet', 'tv', 'telefon', 'phone', 'kabel', 'broadband'],
@@ -81,24 +69,11 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
     ['handwerk', 'reparatur', 'maintenance', 'repair', 'handwerker'],
     'maintenance',
   ],
-  [['mobel', 'möbel', 'furniture', 'furniture'], 'furniture'],
+  [['mobel', 'möbel', 'furniture'], 'furniture'],
   [['garten', 'gardening', 'garden', 'pflanzen', 'plants'], 'gardening'],
-  [
-    ['haushalt', 'household', 'reinigung', 'cleaning', 'cleaning'],
-    'household-supplies',
-  ],
+  [['haushalt', 'household', 'reinigung', 'cleaning'], 'household-supplies'],
   // Life
-  [
-    [
-      'versicherung',
-      'insurance',
-      'versicherung',
-      'haftpflicht',
-      'kasko',
-      'kfz',
-    ],
-    'insurance',
-  ],
+  [['versicherung', 'insurance', 'haftpflicht', 'kasko'], 'insurance'],
   [
     [
       'arzt',
@@ -113,53 +88,51 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
     ],
     'medical-expenses',
   ],
-  [['steuer', 'tax', 'taxes', 'steuer'], 'taxes'],
+  [['steuer', 'tax', 'taxes'], 'taxes'],
   [
-    [
-      'kind',
-      'child',
-      'kita',
-      'kinder',
-      'school',
-      'schule',
-      'education',
-      'unterkunft',
-    ],
+    ['kind', 'child', 'kita', 'kinder', 'school', 'schule', 'education'],
     'childcare',
   ],
   [['kleidung', 'clothing', 'shoppen', 'shopping', 'kauf', 'shop'], 'clothing'],
   [['geschenk', 'gift', 'gifts', 'spende', 'donation'], 'gifts'],
   // Transportation
-  [
-    ['tanken', 'benzin', 'diesel', 'fuel', 'gas', 'kraftstoff', 'benzin'],
-    'gas-fuel',
-  ],
+  [['tanken', 'diesel', 'fuel', 'kraftstoff', 'benzin'], 'gas-fuel'],
   [['parken', 'parking', 'parkplatz'], 'parking'],
   [['vignette', 'maut', 'toll', 'tolls', 'autobahn'], 'tolls'],
-  [['taxi', 'uber', 'taxi'], 'taxi'],
+  [['taxi', 'uber'], 'taxi'],
   [
-    ['bahn', 'bus', 'train', 'ubahn', 's-bahn', 'suv', 'bus/train', 'public'],
+    ['bahn', 'bus', 'train', 'ubahn', 's-bahn', 'bus/train', 'public'],
     'bus-train',
   ],
+  [['flug', 'flughafen', 'plane', 'flight', 'airline'], 'plane'],
   [
     [
-      'flug',
-      'flughafen',
-      'plane',
-      'flight',
-      'airline',
       'hotel',
-      'reise',
-      'trip',
+      'unterkunft',
+      'hostel',
+      'motel',
+      'airbnb',
+      'lodging',
+      'accommodation',
     ],
     'hotel',
   ],
   [
-    ['auto', 'car', 'kfz', 'fahrzeug', 'vehicle', 'fahrrad', 'bicycle', 'bike'],
+    [
+      'auto',
+      'car',
+      'kfz',
+      'fahrzeug',
+      'vehicle',
+      'fahrrad',
+      'bicycle',
+      'bike',
+      'suv',
+    ],
     'car',
   ],
   [
-    ['verkehr', 'transport', 'transportation', 'anfahrt', 'reise'],
+    ['verkehr', 'transport', 'transportation', 'anfahrt', 'reise', 'trip'],
     'transportation',
   ],
   // Entertainment
@@ -183,10 +156,7 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
     ],
     'events-and-activities',
   ],
-  [
-    ['vergnuegen', 'vergnügen', 'entertainment', 'entertainment'],
-    'entertainment',
-  ],
+  [['vergnuegen', 'vergnügen', 'entertainment'], 'entertainment'],
   // Subscriptions
   [
     [
@@ -202,24 +172,17 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
     'subscriptions-and-memberships',
   ],
   // Utilities / services
-  [
-    ['strom', 'wasser', 'gas', 'utility', 'utilities', 'nebenkosten'],
-    'utilities',
-  ],
-  [['service', 'services', 'dienstleistung', 'handwerk'], 'services'],
+  [['utility', 'utilities', 'nebenkosten'], 'utilities'],
+  [['service', 'services', 'dienstleistung'], 'services'],
   // Income
   [
-    [
-      'gehalt',
-      'salary',
-      'einkommen',
-      'income',
-      'lohn',
-      'gage',
-      'gehalt',
-      'bonus',
-    ],
+    ['salary', 'einkommen', 'income', 'lohn', 'gage', 'gehalt', 'bonus'],
     'income',
+  ],
+  // Settlement / Reimbursement
+  [
+    ['reimbursement', 'rückzahlung', 'ausgleich', 'settlement', 'repayment'],
+    'settlement',
   ],
 ]
 

--- a/packages/domain/src/import/cospend-categories.ts
+++ b/packages/domain/src/import/cospend-categories.ts
@@ -72,34 +72,11 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
   [['mobel', 'möbel', 'furniture'], 'furniture'],
   [['garten', 'gardening', 'garden', 'pflanzen', 'plants'], 'gardening'],
   [['haushalt', 'household', 'reinigung', 'cleaning'], 'household-supplies'],
-  // Life
-  [['versicherung', 'insurance', 'haftpflicht', 'kasko'], 'insurance'],
-  [
-    [
-      'arzt',
-      'apotheke',
-      'medical',
-      'health',
-      'gesundheit',
-      'zahnarzt',
-      'dental',
-      'medication',
-      'arznei',
-    ],
-    'medical-expenses',
-  ],
-  [['steuer', 'tax', 'taxes'], 'taxes'],
-  [
-    ['kind', 'child', 'kita', 'kinder', 'school', 'schule', 'education'],
-    'childcare',
-  ],
-  [['kleidung', 'clothing', 'shoppen', 'shopping', 'kauf', 'shop'], 'clothing'],
-  [['geschenk', 'gift', 'gifts', 'spende', 'donation'], 'gifts'],
   // Transportation
+  [['taxi', 'uber'], 'taxi'],
   [['tanken', 'diesel', 'fuel', 'kraftstoff', 'benzin'], 'gas-fuel'],
   [['parken', 'parking', 'parkplatz'], 'parking'],
   [['vignette', 'maut', 'toll', 'tolls', 'autobahn'], 'tolls'],
-  [['taxi', 'uber'], 'taxi'],
   [
     ['bahn', 'bus', 'train', 'ubahn', 's-bahn', 'bus/train', 'public'],
     'bus-train',
@@ -135,6 +112,29 @@ const KEYWORDS: Array<[readonly string[], CategoryId]> = [
     ['verkehr', 'transport', 'transportation', 'anfahrt', 'reise', 'trip'],
     'transportation',
   ],
+  // Life
+  [['versicherung', 'insurance', 'haftpflicht', 'kasko'], 'insurance'],
+  [
+    [
+      'arzt',
+      'apotheke',
+      'medical',
+      'health',
+      'gesundheit',
+      'zahnarzt',
+      'dental',
+      'medication',
+      'arznei',
+    ],
+    'medical-expenses',
+  ],
+  [['steuer', 'tax', 'taxes'], 'taxes'],
+  [
+    ['kind', 'child', 'kita', 'kinder', 'school', 'schule', 'education'],
+    'childcare',
+  ],
+  [['kleidung', 'clothing', 'shoppen', 'shopping', 'kauf', 'shop'], 'clothing'],
+  [['geschenk', 'gift', 'gifts', 'spende', 'donation'], 'gifts'],
   // Entertainment
   [['kino', 'movies', 'movie', 'cinema', 'film'], 'movies'],
   [['musik', 'music', 'konzert', 'concert', 'cd'], 'music'],
@@ -193,7 +193,17 @@ export function cospendCategoryToId(
   const normalized = name.trim().toLowerCase()
   if (!normalized) return 'general'
   for (const [keywords, categoryId] of KEYWORDS) {
-    if (keywords.some((keyword) => normalized.includes(keyword))) {
+    if (
+      keywords.some((keyword) => {
+        if (normalized === keyword) return true
+        const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        const pattern = new RegExp(
+          `(^|[^\\p{L}\\p{N}])${escaped}([^\\p{L}\\p{N}]|$)`,
+          'u',
+        )
+        return pattern.test(normalized)
+      })
+    ) {
       return categoryId
     }
   }

--- a/packages/domain/src/import/cospend-categories.ts
+++ b/packages/domain/src/import/cospend-categories.ts
@@ -1,0 +1,238 @@
+import type { CategoryId } from '../categories'
+
+/**
+ * Best-effort mapping of Cospend category names to Spliit category ids.
+ *
+ * Cospend categories are user-defined and may be in any language, so this is a
+ * keyword-based heuristic that falls back to `general` when nothing matches.
+ * Matching is case-insensitive and runs on the trimmed, lower-cased name.
+ */
+const KEYWORDS: Array<[readonly string[], CategoryId]> = [
+  // Food & drink
+  [
+    [
+      'lebensmittel',
+      'supermarkt',
+      'rewe',
+      'lidl',
+      'aldi',
+      'markt',
+      'grocer',
+      'groceries',
+      'supermarket',
+      'lebensmittel',
+    ],
+    'groceries',
+  ],
+  [
+    [
+      'restaurant',
+      'essen',
+      'kantine',
+      'cafe',
+      'café',
+      'pizzeria',
+      'pizza',
+      'bistro',
+      'dining',
+      'fastfood',
+      'fast food',
+      'imbiss',
+    ],
+    'dining-out',
+  ],
+  [
+    [
+      'getraenk',
+      'getränke',
+      'drink',
+      'drinks',
+      'bar',
+      'kneipe',
+      'bier',
+      'liquor',
+      'alcohol',
+      'alkohol',
+    ],
+    'liquor',
+  ],
+  [
+    [
+      'lebensmittel',
+      'food',
+      'essen',
+      'snack',
+      'imbiß',
+      'imbiss',
+      'verpflegung',
+    ],
+    'food-and-drink',
+  ],
+  // Home
+  [['miete', 'rent', 'miete'], 'rent'],
+  [['strom', 'electricity', 'strom', 'energie', 'energy'], 'electricity'],
+  [['gas', 'heizung', 'heat', 'warme', 'wärme', 'gas'], 'heat-gas'],
+  [['wasser', 'water'], 'water'],
+  [
+    ['internet', 'tv', 'telefon', 'phone', 'kabel', 'broadband'],
+    'tv-phone-internet',
+  ],
+  [
+    ['handwerk', 'reparatur', 'maintenance', 'repair', 'handwerker'],
+    'maintenance',
+  ],
+  [['mobel', 'möbel', 'furniture', 'furniture'], 'furniture'],
+  [['garten', 'gardening', 'garden', 'pflanzen', 'plants'], 'gardening'],
+  [
+    ['haushalt', 'household', 'reinigung', 'cleaning', 'cleaning'],
+    'household-supplies',
+  ],
+  // Life
+  [
+    [
+      'versicherung',
+      'insurance',
+      'versicherung',
+      'haftpflicht',
+      'kasko',
+      'kfz',
+    ],
+    'insurance',
+  ],
+  [
+    [
+      'arzt',
+      'apotheke',
+      'medical',
+      'health',
+      'gesundheit',
+      'zahnarzt',
+      'dental',
+      'medication',
+      'arznei',
+    ],
+    'medical-expenses',
+  ],
+  [['steuer', 'tax', 'taxes', 'steuer'], 'taxes'],
+  [
+    [
+      'kind',
+      'child',
+      'kita',
+      'kinder',
+      'school',
+      'schule',
+      'education',
+      'unterkunft',
+    ],
+    'childcare',
+  ],
+  [['kleidung', 'clothing', 'shoppen', 'shopping', 'kauf', 'shop'], 'clothing'],
+  [['geschenk', 'gift', 'gifts', 'spende', 'donation'], 'gifts'],
+  // Transportation
+  [
+    ['tanken', 'benzin', 'diesel', 'fuel', 'gas', 'kraftstoff', 'benzin'],
+    'gas-fuel',
+  ],
+  [['parken', 'parking', 'parkplatz'], 'parking'],
+  [['vignette', 'maut', 'toll', 'tolls', 'autobahn'], 'tolls'],
+  [['taxi', 'uber', 'taxi'], 'taxi'],
+  [
+    ['bahn', 'bus', 'train', 'ubahn', 's-bahn', 'suv', 'bus/train', 'public'],
+    'bus-train',
+  ],
+  [
+    [
+      'flug',
+      'flughafen',
+      'plane',
+      'flight',
+      'airline',
+      'hotel',
+      'reise',
+      'trip',
+    ],
+    'hotel',
+  ],
+  [
+    ['auto', 'car', 'kfz', 'fahrzeug', 'vehicle', 'fahrrad', 'bicycle', 'bike'],
+    'car',
+  ],
+  [
+    ['verkehr', 'transport', 'transportation', 'anfahrt', 'reise'],
+    'transportation',
+  ],
+  // Entertainment
+  [['kino', 'movies', 'movie', 'cinema', 'film'], 'movies'],
+  [['musik', 'music', 'konzert', 'concert', 'cd'], 'music'],
+  [['sport', 'sports', 'fitness', 'gym', 'turnhalle', 'verein'], 'sports'],
+  [['spiel', 'games', 'game', 'spielen', 'console'], 'games'],
+  [
+    [
+      'ausflug',
+      'kultur',
+      'event',
+      'events',
+      'aktivitaet',
+      'aktivität',
+      'activity',
+      'freizeit',
+      'hobby',
+      'spaß',
+      'spass',
+    ],
+    'events-and-activities',
+  ],
+  [
+    ['vergnuegen', 'vergnügen', 'entertainment', 'entertainment'],
+    'entertainment',
+  ],
+  // Subscriptions
+  [
+    [
+      'abo',
+      'subscription',
+      'subscriptions',
+      'streaming',
+      'netflix',
+      'spotify',
+      'mitgliedschaft',
+      'membership',
+    ],
+    'subscriptions-and-memberships',
+  ],
+  // Utilities / services
+  [
+    ['strom', 'wasser', 'gas', 'utility', 'utilities', 'nebenkosten'],
+    'utilities',
+  ],
+  [['service', 'services', 'dienstleistung', 'handwerk'], 'services'],
+  // Income
+  [
+    [
+      'gehalt',
+      'salary',
+      'einkommen',
+      'income',
+      'lohn',
+      'gage',
+      'gehalt',
+      'bonus',
+    ],
+    'income',
+  ],
+]
+
+export function cospendCategoryToId(
+  name: string | null | undefined,
+): CategoryId {
+  if (!name) return 'general'
+  const normalized = name.trim().toLowerCase()
+  if (!normalized) return 'general'
+  for (const [keywords, categoryId] of KEYWORDS) {
+    if (keywords.some((keyword) => normalized.includes(keyword))) {
+      return categoryId
+    }
+  }
+  return 'general'
+}

--- a/packages/domain/src/import/cospend-csv.test.ts
+++ b/packages/domain/src/import/cospend-csv.test.ts
@@ -454,6 +454,13 @@ describe('cospendCategoryToId', () => {
     expect(cospendCategoryToId('Rückzahlung')).toBe('settlement')
   })
 
+  it('resolves taxi to taxi rather than taxes (word boundary regression)', () => {
+    expect(cospendCategoryToId('taxi')).toBe('taxi')
+    expect(cospendCategoryToId('Taxi')).toBe('taxi')
+    expect(cospendCategoryToId('tax')).toBe('taxes')
+    expect(cospendCategoryToId('Taxes')).toBe('taxes')
+  })
+
   it('falls back to general for unknown or empty names', () => {
     expect(cospendCategoryToId('Blablabla')).toBe('general')
     expect(cospendCategoryToId('')).toBe('general')

--- a/packages/domain/src/import/cospend-csv.test.ts
+++ b/packages/domain/src/import/cospend-csv.test.ts
@@ -339,14 +339,52 @@ describe('tryParseCospendCsv', () => {
             date: '2026-08-06',
             payer: 'Alex',
             owers: 'Alex,Sam',
-            comment: 'H%20guten%20Appetit',
+            comment: 'pizza+%26+drinks',
           },
         ],
       }),
     )
     expect(result.ok).toBe(true)
     if (!result.ok) return
-    expect(result.source.expenses[0]!.notes).toBe('H guten Appetit')
+    expect(result.source.expenses[0]!.notes).toBe('pizza & drinks')
+  })
+
+  it('maps categoryid -11 to settlement', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'Alex paid Sam',
+            amount: 15,
+            date: '2026-08-05',
+            payer: 'Alex',
+            owers: 'Sam',
+            categoryid: -11,
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source.expenses[0]!.category).toBe('settlement')
+  })
+
+  it('preserves DEFAULT_CURRENCY when main currency row has an empty name', () => {
+    const csv = [
+      'name,weight,active,color',
+      '"Alex",1,1,"#d6b461"',
+      '',
+      'what,amount,date,timestamp,payer_name,payer_weight,payer_active,owers,repeat,repeatfreq,repeatallactive,repeatuntil,categoryid,paymentmode,paymentmodeid,comment,deleted',
+      '"Bill",10,2026-08-02,1785690155,"Alex",1,1,"Alex",n,1,0,,0,n,0,"",0',
+      '',
+      'currencyname,exchange_rate',
+      '"",1',
+      '"CHF",0.92',
+    ].join('\n')
+    const result = tryParseCospendCsv(csv)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source.currencyCode).toBe('EUR')
   })
 
   it('uses the first currency row as the base currency', () => {
@@ -410,6 +448,10 @@ describe('cospendCategoryToId', () => {
     expect(cospendCategoryToId('Restaurant')).toBe('dining-out')
     expect(cospendCategoryToId('Miete')).toBe('rent')
     expect(cospendCategoryToId('insurance')).toBe('insurance')
+    expect(cospendCategoryToId('Unterkunft')).toBe('hotel')
+    expect(cospendCategoryToId('Flug')).toBe('plane')
+    expect(cospendCategoryToId('SUV')).toBe('car')
+    expect(cospendCategoryToId('Rückzahlung')).toBe('settlement')
   })
 
   it('falls back to general for unknown or empty names', () => {

--- a/packages/domain/src/import/cospend-csv.test.ts
+++ b/packages/domain/src/import/cospend-csv.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it } from 'vitest'
+
+import { cospendCategoryToId } from './cospend-categories'
+import { tryParseCospendCsv } from './cospend-csv'
+
+/**
+ * Build a minimal Cospend project CSV. Sections are separated by a single blank
+ * line, matching the real export format.
+ */
+function cospendCsv(
+  opts: {
+    members?: Array<[name: string, weight: number]>
+    bills?: Array<{
+      what: string
+      amount: number
+      date: string
+      payer: string
+      owers: string
+      repeat?: string
+      repeatfreq?: number
+      repeatuntil?: string
+      categoryid?: string | number
+      comment?: string
+      deleted?: number
+    }>
+    categories?: Array<[name: string, id: number]>
+    currencies?: string[]
+  } = {},
+): string {
+  const members = opts.members ?? [
+    ['Alex', 1],
+    ['Sam', 1],
+  ]
+  const lines: string[] = []
+  lines.push('name,weight,active,color')
+  for (const [name, weight] of members) {
+    lines.push(`"${name}",${weight},1,"#d6b461"`)
+  }
+  lines.push('')
+  lines.push(
+    'what,amount,date,timestamp,payer_name,payer_weight,payer_active,owers,repeat,repeatfreq,repeatallactive,repeatuntil,categoryid,paymentmode,paymentmodeid,comment,deleted',
+  )
+  for (const b of opts.bills ?? []) {
+    lines.push(
+      `"${b.what}",${b.amount},${b.date},1785690155,"${b.payer}",1,1,"${b.owers}",${b.repeat ?? 'n'},${b.repeatfreq ?? 1},0,${b.repeatuntil ?? ''},${b.categoryid ?? 0},n,0,"${b.comment ?? ''}",${b.deleted ?? 0}`,
+    )
+  }
+  if (opts.categories) {
+    lines.push('')
+    lines.push('categoryname,categoryid,icon,color')
+    for (const [name, id] of opts.categories) {
+      lines.push(`"${name}",${id},"🏠","#da8733"`)
+    }
+  }
+  if (opts.currencies) {
+    lines.push('')
+    lines.push('currencyname,exchange_rate')
+    for (const code of opts.currencies) {
+      lines.push(`"${code}",1.0`)
+    }
+  }
+  return lines.join('\n')
+}
+
+describe('tryParseCospendCsv', () => {
+  it('parses members and a basic bill', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'Parken DUS',
+            amount: 10,
+            date: '2026-08-02',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source.provider).toBe('COSPEND')
+    expect(result.source.name).toBe('Imported from Cospend')
+    expect(result.source.currencyCode).toBe('EUR')
+    expect(result.source.participants).toEqual([
+      { sourceId: 'cospend-member-0', sourceName: 'Alex' },
+      { sourceId: 'cospend-member-1', sourceName: 'Sam' },
+    ])
+    expect(result.source.expenses).toHaveLength(1)
+    const expense = result.source.expenses[0]!
+    expect(expense.title).toBe('Parken DUS')
+    expect(expense.expenseDate).toBe('2026-08-02')
+    expect(expense.amount).toBe(1000)
+    expect(expense.amountCurrency).toBe('EUR')
+    expect(expense.paidBySourceId).toBe('cospend-member-0')
+    // Even split between two equal-weight members.
+    expect(expense.paidFor).toEqual([
+      { sourceId: 'cospend-member-0', shares: 500 },
+      { sourceId: 'cospend-member-1', shares: 500 },
+    ])
+    expect(expense.splitMode).toBe('EVENLY')
+    expect(expense.recurrence).toBeNull()
+    expect(expense.recurrenceRule).toBe('NONE')
+  })
+
+  it('splits proportionally to member weights', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        members: [
+          ['Alex', 1],
+          ['Sam', 3],
+        ],
+        bills: [
+          {
+            what: 'Miete',
+            amount: 400,
+            date: '2026-08-01',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const expense = result.source.expenses[0]!
+    // Alex (weight 1) : Sam (weight 3) → BY_SHARES normalised to a 1:3 ratio.
+    // The actual amounts (100.00 / 300.00) are recomputed from this ratio.
+    expect(expense.paidFor).toEqual([
+      { sourceId: 'cospend-member-0', shares: 100 },
+      { sourceId: 'cospend-member-1', shares: 300 },
+    ])
+    expect(expense.splitMode).toBe('BY_SHARES')
+  })
+
+  it('maps monthly recurrence to a MONTHLY config', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'Spotify',
+            amount: 10.99,
+            date: '2026-08-01',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            repeat: 'm',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const expense = result.source.expenses[0]!
+    expect(expense.recurrence).toEqual({
+      frequency: 'MONTHLY',
+      interval: 1,
+      end: { type: 'INDEFINITE' },
+    })
+    // A plain monthly schedule maps back to the legacy MONTHLY rule.
+    expect(expense.recurrenceRule).toBe('MONTHLY')
+  })
+
+  it('maps yearly recurrence to a YEARLY config with a NONE legacy rule', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'KFZ Haftpflicht',
+            amount: 500,
+            date: '2026-08-01',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            repeat: 'y',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const expense = result.source.expenses[0]!
+    expect(expense.recurrence).toEqual({
+      frequency: 'YEARLY',
+      interval: 1,
+      end: { type: 'INDEFINITE' },
+    })
+    // Yearly has no legacy equivalent, so the rule is NONE.
+    expect(expense.recurrenceRule).toBe('NONE')
+  })
+
+  it('multiplies the interval by repeatfreq', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'GEZ',
+            amount: 18.36,
+            date: '2026-08-01',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            repeat: 'm',
+            repeatfreq: 3,
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const expense = result.source.expenses[0]!
+    expect(expense.recurrence).toEqual({
+      frequency: 'MONTHLY',
+      interval: 3,
+      end: { type: 'INDEFINITE' },
+    })
+    // Interval > 1 has no legacy equivalent, so the rule is NONE.
+    expect(expense.recurrenceRule).toBe('NONE')
+  })
+
+  it('maps biweekly to WEEKLY with interval 2', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'Einkauf',
+            amount: 50,
+            date: '2026-08-01',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            repeat: 'b',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const expense = result.source.expenses[0]!
+    expect(expense.recurrence).toEqual({
+      frequency: 'WEEKLY',
+      interval: 2,
+      end: { type: 'INDEFINITE' },
+    })
+  })
+
+  it('honours a dated repeatuntil as a DATE end', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'Strom',
+            amount: 100,
+            date: '2026-08-01',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            repeat: 'm',
+            repeatuntil: '2027-01-01',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const expense = result.source.expenses[0]!
+    expect(expense.recurrence).toEqual({
+      frequency: 'MONTHLY',
+      interval: 1,
+      end: { type: 'DATE', endDate: new Date('2027-01-01T00:00:00.000Z') },
+    })
+    // A dated end has no legacy equivalent, so the rule is NONE.
+    expect(expense.recurrenceRule).toBe('NONE')
+  })
+
+  it('skips deleted bills', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'Kept',
+            amount: 10,
+            date: '2026-08-02',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+          },
+          {
+            what: 'Deleted',
+            amount: 20,
+            date: '2026-08-03',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            deleted: 1,
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source.expenses).toHaveLength(1)
+    expect(result.source.expenses[0]!.title).toBe('Kept')
+  })
+
+  it('maps known categories and falls back to general', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        categories: [
+          ['Miete', 129],
+          ['Strom', 130],
+        ],
+        bills: [
+          {
+            what: 'Miete',
+            amount: 500,
+            date: '2026-08-01',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            categoryid: 129,
+          },
+          {
+            what: 'Mystery',
+            amount: 10,
+            date: '2026-08-02',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            categoryid: 999,
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source.expenses[0]!.category).toBe('rent')
+    expect(result.source.expenses[1]!.category).toBe('general')
+  })
+
+  it('decodes URL-encoded comments into notes', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        bills: [
+          {
+            what: 'Pizza',
+            amount: 20,
+            date: '2026-08-06',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+            comment: 'H%20guten%20Appetit',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source.expenses[0]!.notes).toBe('H guten Appetit')
+  })
+
+  it('uses the first currency row as the base currency', () => {
+    const result = tryParseCospendCsv(
+      cospendCsv({
+        currencies: ['USD', 'EUR'],
+        bills: [
+          {
+            what: 'Bill',
+            amount: 10,
+            date: '2026-08-02',
+            payer: 'Alex',
+            owers: 'Alex,Sam',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.source.currencyCode).toBe('USD')
+    expect(result.source.expenses[0]!.amountCurrency).toBe('USD')
+  })
+
+  it('rejects files that are not Cospend exports', () => {
+    const result = tryParseCospendCsv('a,b,c\n1,2,3\n')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/members or bills/i)
+  })
+
+  it('rejects exports with no members', () => {
+    const csv = [
+      'name,weight,active,color',
+      '',
+      'what,amount,date,timestamp,payer_name,payer_weight,payer_active,owers,repeat,repeatfreq,repeatallactive,repeatuntil,categoryid,paymentmode,paymentmodeid,comment,deleted',
+      '"Bill",10,2026-08-02,1785690155,"Alex",1,1,"Alex",n,1,0,,0,n,0,"",0',
+    ].join('\n')
+    const result = tryParseCospendCsv(csv)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/no members/i)
+  })
+
+  it('rejects exports with no parseable bills', () => {
+    const csv = [
+      'name,weight,active,color',
+      '"Alex",1,1,"#d6b461"',
+      '',
+      'what,amount,date,timestamp,payer_name,payer_weight,payer_active,owers,repeat,repeatfreq,repeatallactive,repeatuntil,categoryid,paymentmode,paymentmodeid,comment,deleted',
+    ].join('\n')
+    const result = tryParseCospendCsv(csv)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/no parseable bills/i)
+  })
+})
+
+describe('cospendCategoryToId', () => {
+  it('maps German and English keywords', () => {
+    expect(cospendCategoryToId('Lebensmittel')).toBe('groceries')
+    expect(cospendCategoryToId('Restaurant')).toBe('dining-out')
+    expect(cospendCategoryToId('Miete')).toBe('rent')
+    expect(cospendCategoryToId('insurance')).toBe('insurance')
+  })
+
+  it('falls back to general for unknown or empty names', () => {
+    expect(cospendCategoryToId('Blablabla')).toBe('general')
+    expect(cospendCategoryToId('')).toBe('general')
+    expect(cospendCategoryToId(null)).toBe('general')
+  })
+})

--- a/packages/domain/src/import/cospend-csv.ts
+++ b/packages/domain/src/import/cospend-csv.ts
@@ -1,5 +1,6 @@
 import Papa from 'papaparse'
 
+import { SETTLEMENT_CATEGORY_ID } from '../categories'
 import { getCurrency } from '../currency'
 import { distributeRemainder } from '../remainder-distribution'
 import { calculateExactShares } from '../totals'
@@ -191,13 +192,30 @@ export function tryParseCospendCsv(input: string): ImportParseResult {
     }
   }
 
-  // ── Currencies (base currency = first row) ────────────────────────────
+  // ── Currencies (main currency = row with exchange_rate 1, or first row) ──
   let baseCurrency = DEFAULT_CURRENCY
   if (currenciesStart !== -1) {
     for (let r = currenciesStart + 1; r < rows.length; r++) {
       const row = rows[r]
       if (isBlank(row)) continue
+      if (
+        isHeader(row, MEMBER_HEADER) ||
+        isHeader(row, BILL_HEADER) ||
+        isHeader(row, CATEGORY_HEADER) ||
+        isHeader(row, PAYMENTMODE_HEADER)
+      ) {
+        break
+      }
       const code = (row[0] ?? '').trim().toUpperCase()
+      const rate = toNumberOrNull(row[1])
+      // Upstream always writes the main currency first with exchange_rate = 1.
+      // If the project had no custom currency name set, this row is ("", 1).
+      // In that case, keep DEFAULT_CURRENCY rather than scanning forward to an
+      // additional currency with exchange_rate != 1.
+      if (rate === 1) {
+        if (code) baseCurrency = code
+        break
+      }
       if (code) {
         baseCurrency = code
         break
@@ -299,7 +317,7 @@ export function tryParseCospendCsv(input: string): ImportParseResult {
     let notes: string | null = null
     if (comment) {
       try {
-        notes = decodeURIComponent(comment)
+        notes = decodeURIComponent(comment.replace(/\+/g, ' '))
       } catch {
         notes = comment
       }
@@ -308,7 +326,10 @@ export function tryParseCospendCsv(input: string): ImportParseResult {
     const categoryName = categoryId
       ? (categoryIdToName.get(categoryId) ?? null)
       : null
-    const category = cospendCategoryToId(categoryName)
+    const category =
+      categoryId === '-11'
+        ? SETTLEMENT_CATEGORY_ID
+        : cospendCategoryToId(categoryName)
 
     expenses.push({
       title: what,

--- a/packages/domain/src/import/cospend-csv.ts
+++ b/packages/domain/src/import/cospend-csv.ts
@@ -1,0 +1,352 @@
+import Papa from 'papaparse'
+
+import { getCurrency } from '../currency'
+import { distributeRemainder } from '../remainder-distribution'
+import { calculateExactShares } from '../totals'
+import { amountAsMinorUnitsByCode } from '../utils'
+import { cospendCategoryToId } from './cospend-categories'
+import { recurrenceToLegacyRule } from './recurrence'
+import { guessSplitMode } from './split-guess'
+import type {
+  ImportParseResult,
+  NormalizedSource,
+  RecurrenceConfig,
+} from './types'
+
+/**
+ * Base currency assumed when the Cospend export carries no currencies section.
+ * Cospend only writes the currencies block when a project has additional
+ * currencies; the base currency is otherwise implicit. EUR is the default for
+ * the (predominantly European) Cospend user base and can be corrected in the
+ * destination step.
+ */
+const DEFAULT_CURRENCY = 'EUR'
+
+/**
+ * Cospend `repeat` codes mapped to a base frequency and base interval. `b`
+ * (biweekly) is two weeks; `s` (semi-monthly) has no direct Spliit equivalent
+ * and is approximated as monthly. The exported `repeatfreq` multiplies the base
+ * interval.
+ */
+const REPEAT_BASE: Record<
+  string,
+  { frequency: RecurrenceConfig['frequency']; baseInterval: number }
+> = {
+  d: { frequency: 'DAILY', baseInterval: 1 },
+  w: { frequency: 'WEEKLY', baseInterval: 1 },
+  b: { frequency: 'WEEKLY', baseInterval: 2 },
+  s: { frequency: 'MONTHLY', baseInterval: 1 },
+  m: { frequency: 'MONTHLY', baseInterval: 1 },
+  y: { frequency: 'YEARLY', baseInterval: 1 },
+}
+
+const MEMBER_HEADER = ['name', 'weight', 'active', 'color']
+const BILL_HEADER = [
+  'what',
+  'amount',
+  'date',
+  'timestamp',
+  'payer_name',
+  'payer_weight',
+  'payer_active',
+  'owers',
+  'repeat',
+  'repeatfreq',
+  'repeatallactive',
+  'repeatuntil',
+  'categoryid',
+  'paymentmode',
+  'paymentmodeid',
+  'comment',
+  'deleted',
+]
+const CATEGORY_HEADER = ['categoryname', 'categoryid', 'icon', 'color']
+const PAYMENTMODE_HEADER = ['paymentmodename', 'paymentmodeid', 'icon', 'color']
+const CURRENCY_HEADER = ['currencyname', 'exchange_rate']
+
+function toNumberOrNull(value: string | undefined): number | null {
+  if (value === undefined) return null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  const n = Number(trimmed)
+  return Number.isNaN(n) ? null : n
+}
+
+function isHeader(
+  row: string[] | undefined,
+  header: readonly string[],
+): boolean {
+  if (!row) return false
+  if (row.length < header.length) return false
+  return header.every((cell, i) => (row[i] ?? '').trim() === cell)
+}
+
+function isBlank(row: string[]): boolean {
+  return row.every((c) => (c ?? '').trim() === '')
+}
+
+/** Build a RecurrenceConfig from Cospend repeat metadata, or null if none. */
+function parseCospendRepeat(
+  repeat: string,
+  repeatFreq: number,
+  repeatUntil: string,
+): RecurrenceConfig | null {
+  const base = REPEAT_BASE[repeat]
+  if (!base) return null
+  const multiplier =
+    Number.isFinite(repeatFreq) && repeatFreq > 0 ? repeatFreq : 1
+  const interval = Math.min(99, Math.max(1, base.baseInterval * multiplier))
+  const until = repeatUntil.trim()
+  const end: RecurrenceConfig['end'] = /^\d{4}-\d{2}-\d{2}$/.test(until)
+    ? { type: 'DATE', endDate: new Date(`${until}T00:00:00.000Z`) }
+    : { type: 'INDEFINITE' }
+  return { frequency: base.frequency, interval, end }
+}
+
+/**
+ * Parse a Cospend project CSV export into a normalized import source.
+ *
+ * Cospend exports one CSV per project with five sections (members, bills,
+ * categories, payment modes, and optionally currencies) separated by blank
+ * lines. The project name is not in the file body — only the filename slug — so
+ * the group name defaults here and is refined from the filename upstream.
+ */
+export function tryParseCospendCsv(input: string): ImportParseResult {
+  const cleaned = input.charCodeAt(0) === 0xfeff ? input.slice(1) : input
+  const parsed = Papa.parse<string[]>(cleaned, {
+    skipEmptyLines: 'greedy',
+    header: false,
+  })
+
+  if (parsed.errors.length > 0) {
+    return {
+      ok: false,
+      error: `CSV could not be parsed: ${parsed.errors[0]?.message ?? 'unknown error'}`,
+    }
+  }
+
+  const rows = parsed.data
+
+  // ── Locate section headers ────────────────────────────────────────────
+  let membersStart = -1
+  let billsStart = -1
+  let categoriesStart = -1
+  let currenciesStart = -1
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]
+    if (membersStart === -1 && isHeader(row, MEMBER_HEADER)) membersStart = i
+    else if (billsStart === -1 && isHeader(row, BILL_HEADER)) billsStart = i
+    else if (categoriesStart === -1 && isHeader(row, CATEGORY_HEADER))
+      categoriesStart = i
+    else if (currenciesStart === -1 && isHeader(row, CURRENCY_HEADER))
+      currenciesStart = i
+  }
+
+  if (membersStart === -1 || billsStart === -1) {
+    return {
+      ok: false,
+      error:
+        'CSV is not a Cospend project export (missing members or bills section)',
+    }
+  }
+
+  // ── Members ───────────────────────────────────────────────────────────
+  const participants: NormalizedSource['participants'] = []
+  const nameToSourceId = new Map<string, string>()
+  const nameToWeight = new Map<string, number>()
+  for (let r = membersStart + 1; r < rows.length; r++) {
+    const row = rows[r]
+    if (isBlank(row)) continue
+    if (
+      isHeader(row, BILL_HEADER) ||
+      isHeader(row, CATEGORY_HEADER) ||
+      isHeader(row, PAYMENTMODE_HEADER) ||
+      isHeader(row, CURRENCY_HEADER)
+    ) {
+      break
+    }
+    const name = (row[0] ?? '').trim()
+    if (!name) continue
+    const weight = toNumberOrNull(row[1]) ?? 1
+    const sourceId = `cospend-member-${participants.length}`
+    nameToSourceId.set(name, sourceId)
+    nameToWeight.set(name, weight)
+    participants.push({ sourceId, sourceName: name })
+  }
+  if (participants.length === 0) {
+    return { ok: false, error: 'Cospend export has no members' }
+  }
+
+  // ── Categories (name → id) ────────────────────────────────────────────
+  const categoryIdToName = new Map<string, string>()
+  if (categoriesStart !== -1) {
+    for (let r = categoriesStart + 1; r < rows.length; r++) {
+      const row = rows[r]
+      if (isBlank(row)) continue
+      if (isHeader(row, CURRENCY_HEADER) || isHeader(row, PAYMENTMODE_HEADER))
+        break
+      const name = (row[0] ?? '').trim()
+      const id = (row[1] ?? '').trim()
+      if (name && id) categoryIdToName.set(id, name)
+    }
+  }
+
+  // ── Currencies (base currency = first row) ────────────────────────────
+  let baseCurrency = DEFAULT_CURRENCY
+  if (currenciesStart !== -1) {
+    for (let r = currenciesStart + 1; r < rows.length; r++) {
+      const row = rows[r]
+      if (isBlank(row)) continue
+      const code = (row[0] ?? '').trim().toUpperCase()
+      if (code) {
+        baseCurrency = code
+        break
+      }
+    }
+  }
+  const currencyCode = baseCurrency
+  const currency = getCurrency(currencyCode) ?? {
+    code: currencyCode,
+    symbol: currencyCode,
+    rounding: 0,
+    decimal_digits: 2,
+  }
+
+  // ── Bills ─────────────────────────────────────────────────────────────
+  const billsEnd =
+    categoriesStart !== -1
+      ? categoriesStart
+      : currenciesStart !== -1
+        ? currenciesStart
+        : rows.length
+
+  const expenses: NormalizedSource['expenses'] = []
+  for (let r = billsStart + 1; r < billsEnd; r++) {
+    const row = rows[r]
+    if (isBlank(row)) continue
+    const what = (row[0] ?? '').trim()
+    const amount = toNumberOrNull(row[1])
+    const date = (row[2] ?? '').trim()
+    const payerName = (row[4] ?? '').trim()
+    const owersRaw = (row[7] ?? '').trim()
+    const repeat = (row[8] ?? '').trim()
+    const repeatFreq = toNumberOrNull(row[9]) ?? 1
+    const repeatUntil = (row[11] ?? '').trim()
+    const categoryId = (row[12] ?? '').trim()
+    const comment = (row[15] ?? '').trim()
+    const deleted = (row[16] ?? '').trim()
+
+    if (!what || amount === null || !/^\d{4}-\d{2}-\d{2}/.test(date)) continue
+    if (deleted === '1') continue
+
+    const payerSourceId = nameToSourceId.get(payerName)
+    if (!payerSourceId) continue
+
+    // Owning members share the cost proportionally to their weights.
+    const owerNames = owersRaw
+      .split(',')
+      .map((n) => n.trim())
+      .filter(Boolean)
+    const owers = owerNames
+      .map((n) => ({
+        sourceId: nameToSourceId.get(n),
+        weight: nameToWeight.get(n) ?? 1,
+      }))
+      .filter((o): o is { sourceId: string; weight: number } =>
+        Boolean(o.sourceId),
+      )
+    if (owers.length === 0) continue
+
+    const amountCents = amountAsMinorUnitsByCode(amount, currency.code)
+
+    // Weight-proportional split: scale weights to integers to keep the ratio
+    // exact, then distribute the amount with rational arithmetic.
+    const scaledWeights = owers.map((o) =>
+      Math.round((o.weight > 0 ? o.weight : 1) * 100),
+    )
+    const exact = calculateExactShares({
+      amount: amountCents,
+      splitMode: 'BY_SHARES',
+      participants: owers.map((o, i) => ({
+        id: o.sourceId,
+        shares: scaledWeights[i],
+      })),
+    })
+    const fixed = distributeRemainder(exact, amountCents, {
+      payerId: payerSourceId,
+    })
+
+    const paidFor: Array<{ sourceId: string; shares: number }> = []
+    for (const o of owers) {
+      const shares = fixed[o.sourceId] ?? 0
+      if (shares > 0) paidFor.push({ sourceId: o.sourceId, shares })
+    }
+    if (paidFor.length === 0) continue
+
+    const involvedCount = new Set([
+      payerSourceId,
+      ...paidFor.map((p) => p.sourceId),
+    ]).size
+    const { splitMode, paidFor: resolvedPaidFor } = guessSplitMode(
+      paidFor,
+      amountCents,
+      { involvedParticipantCount: involvedCount },
+    )
+
+    const recurrence = parseCospendRepeat(repeat, repeatFreq, repeatUntil)
+    const recurrenceRule = recurrenceToLegacyRule(recurrence)
+
+    let notes: string | null = null
+    if (comment) {
+      try {
+        notes = decodeURIComponent(comment)
+      } catch {
+        notes = comment
+      }
+    }
+
+    const categoryName = categoryId
+      ? (categoryIdToName.get(categoryId) ?? null)
+      : null
+    const category = cospendCategoryToId(categoryName)
+
+    expenses.push({
+      title: what,
+      expenseDate: date.slice(0, 10),
+      category,
+      amountCurrency: currency.code,
+      amount: amountCents,
+      originalAmount: null,
+      originalCurrency: null,
+      conversionRate: null,
+      paidBySourceId: payerSourceId,
+      paidBy: [{ sourceId: payerSourceId, shares: amountCents }],
+      paidFor: resolvedPaidFor,
+      splitMode,
+      recurrenceRule,
+      recurrence,
+      notes,
+    })
+  }
+
+  if (expenses.length === 0) {
+    return { ok: false, error: 'Cospend export had no parseable bills' }
+  }
+
+  return {
+    ok: true,
+    source: {
+      provider: 'COSPEND',
+      exportVersion: null,
+      sourceGroupId: 'cospend-csv-import',
+      sourceUrl: null,
+      name: 'Imported from Cospend',
+      information: null,
+      currency: currency.code,
+      currencyCode: currency.code,
+      participants,
+      expenses,
+      documentSource: 'NONE',
+    },
+  }
+}

--- a/packages/domain/src/import/filename.test.ts
+++ b/packages/domain/src/import/filename.test.ts
@@ -63,4 +63,14 @@ describe('guessGroupNameFromFilename', () => {
       'Osterreich 2026',
     )
   })
+
+  it('humanizes bare slugs when provider is COSPEND', () => {
+    expect(guessGroupNameFromFilename('family.csv', 'COSPEND')).toBe('Family')
+    expect(guessGroupNameFromFilename('family-zu-besuch.csv', 'COSPEND')).toBe(
+      'Family Zu Besuch',
+    )
+    expect(guessGroupNameFromFilename('family.csv')).toBeNull()
+    expect(guessGroupNameFromFilename('family.csv', 'SPLITWISE')).toBeNull()
+    expect(guessGroupNameFromFilename('12345.csv', 'COSPEND')).toBeNull()
+  })
 })

--- a/packages/domain/src/import/filename.test.ts
+++ b/packages/domain/src/import/filename.test.ts
@@ -54,4 +54,13 @@ describe('guessGroupNameFromFilename', () => {
       guessGroupNameFromFilename('john-d-and-jane-d_2026-06-30_export.json'),
     ).toBe('John D. and Jane D.')
   })
+
+  it('humanizes Cospend dated project slugs', () => {
+    expect(guessGroupNameFromFilename('family-zu-besuch_2026-09-06.csv')).toBe(
+      'Family Zu Besuch',
+    )
+    expect(guessGroupNameFromFilename('osterreich-2026_2026-09-06.csv')).toBe(
+      'Osterreich 2026',
+    )
+  })
 })

--- a/packages/domain/src/import/filename.ts
+++ b/packages/domain/src/import/filename.ts
@@ -15,7 +15,10 @@
  * Returns `null` when the filename doesn't match a known pattern. The caller
  * should keep the parser's default in that case.
  */
-export function guessGroupNameFromFilename(filename: string): string | null {
+export function guessGroupNameFromFilename(
+  filename: string,
+  provider?: string | null,
+): string | null {
   const base = filename.replace(/\.(csv|json)$/i, '')
 
   const personalMatch = base.match(/^(.+)_(\d{4}-\d{2}-\d{2})_export$/)
@@ -47,6 +50,11 @@ export function guessGroupNameFromFilename(filename: string): string | null {
   if (cospendDated) {
     const prefix = cospendDated[1].trim()
     if (prefix && !/^\d+$/.test(prefix)) return humanizeGroupPrefix(prefix)
+  }
+
+  if (provider === 'COSPEND') {
+    const slug = base.trim()
+    if (slug && !/^\d+$/.test(slug)) return humanizeGroupPrefix(slug)
   }
 
   return null

--- a/packages/domain/src/import/filename.ts
+++ b/packages/domain/src/import/filename.ts
@@ -39,6 +39,16 @@ export function guessGroupNameFromFilename(filename: string): string | null {
     return humanizeGroupPrefix(prefix)
   }
 
+  // Cospend project exports are named `<slug>_<date>.csv` (or `<slug>.csv`).
+  // The slug is a lossy lowercased version of the project name (umlauts
+  // stripped, spaces → hyphens/underscores); humanize it as a default. The
+  // date-suffixed form is matched first so a bare slug is a last resort.
+  const cospendDated = base.match(/^(.+)_(\d{4}-\d{2}-\d{2})$/)
+  if (cospendDated) {
+    const prefix = cospendDated[1].trim()
+    if (prefix && !/^\d+$/.test(prefix)) return humanizeGroupPrefix(prefix)
+  }
+
   return null
 }
 

--- a/packages/domain/src/import/index.ts
+++ b/packages/domain/src/import/index.ts
@@ -1,4 +1,6 @@
 export * from './anonymize-splitwise-csv'
+export * from './cospend-categories'
+export * from './cospend-csv'
 export * from './filename'
 export * from './mapping'
 export * from './recurrence'

--- a/packages/domain/src/import/recurrence-collapse.test.ts
+++ b/packages/domain/src/import/recurrence-collapse.test.ts
@@ -11,18 +11,14 @@ import {
 } from './recurrence-collapse'
 
 function expense(
-  overrides: Partial<LegacyRecurringCollapseExpense> & {
-    title?: string
-    expenseDate?: string
-    recurrenceRule?: LegacyRecurringCollapseExpense['recurrenceRule']
-    amount?: number
-  } = {},
+  overrides: Partial<LegacyRecurringCollapseExpense> = {},
 ): LegacyRecurringCollapseExpense {
   return {
     title: overrides.title ?? 'Spotify Monthly',
     expenseDate: overrides.expenseDate ?? '2025-06-19',
     amount: overrides.amount ?? 1000,
     recurrenceRule: overrides.recurrenceRule ?? 'MONTHLY',
+    recurrence: overrides.recurrence ?? null,
     splitMode: overrides.splitMode ?? 'EVENLY',
     category: overrides.category ?? 'general',
     paidBy: overrides.paidBy ?? [{ id: 'p1', shares: 1000 }],
@@ -79,7 +75,7 @@ describe('planLegacyRecurringImport', () => {
       },
     ])
     expect(plan.series[0]!.occurrenceCount).toBe(1)
-    expect(plan.series[0]!.nextOccurrenceDate.toISOString().slice(0, 10)).toBe(
+    expect(plan.series[0]!.nextOccurrenceDate!.toISOString().slice(0, 10)).toBe(
       '2026-08-01',
     )
   })
@@ -94,7 +90,7 @@ describe('planLegacyRecurringImport', () => {
     expect(plan.series).toHaveLength(1)
     expect(plan.series[0]!.occurrenceCount).toBe(3)
     expect(plan.series[0]!.anchorIndex).toBe(2)
-    expect(plan.series[0]!.nextOccurrenceDate.toISOString().slice(0, 10)).toBe(
+    expect(plan.series[0]!.nextOccurrenceDate!.toISOString().slice(0, 10)).toBe(
       '2026-08-19',
     )
     expect(plan.series[0]!.nextOccurrenceOrdinal).toBe(14)
@@ -144,7 +140,7 @@ describe('planLegacyRecurringImport', () => {
     expect(expenses[plan.series[0]!.anchorIndex]!.expenseDate).toBe(
       '2026-06-19',
     )
-    expect(plan.series[0]!.nextOccurrenceDate.toISOString().slice(0, 10)).toBe(
+    expect(plan.series[0]!.nextOccurrenceDate!.toISOString().slice(0, 10)).toBe(
       '2026-08-19',
     )
     expect(plan.series[0]!.nextOccurrenceOrdinal).toBe(3)
@@ -202,7 +198,7 @@ describe('firstRecurrenceDateAfterToday', () => {
       '2026-06-01',
       new Date('2026-07-23T00:00:00.000Z'),
     )
-    expect(next.toISOString().slice(0, 10)).toBe('2026-08-01')
+    expect(next!.toISOString().slice(0, 10)).toBe('2026-08-01')
   })
 })
 
@@ -213,8 +209,8 @@ describe('firstRecurrenceAfterToday', () => {
       '2026-06-01',
       new Date('2026-07-23T00:00:00.000Z'),
     )
-    expect(next.date.toISOString().slice(0, 10)).toBe('2026-08-01')
-    expect(next.ordinal).toBe(3)
+    expect(next!.date.toISOString().slice(0, 10)).toBe('2026-08-01')
+    expect(next!.ordinal).toBe(3)
   })
 
   it('keeps month-end anchors on the 31st after overdue skip (not iterative clamp drift)', () => {
@@ -224,8 +220,8 @@ describe('firstRecurrenceAfterToday', () => {
       '2025-01-31',
       new Date('2026-07-23T00:00:00.000Z'),
     )
-    expect(next.date.toISOString().slice(0, 10)).toBe('2026-07-31')
-    expect(next.ordinal).toBe(19)
+    expect(next!.date.toISOString().slice(0, 10)).toBe('2026-07-31')
+    expect(next!.ordinal).toBe(19)
   })
 
   it('recovers leap-day yearly anchors to Feb 29 (not stuck on iterative Feb 28)', () => {
@@ -236,8 +232,8 @@ describe('firstRecurrenceAfterToday', () => {
       '2024-02-29',
       new Date('2027-03-01T00:00:00.000Z'),
     )
-    expect(next.date.toISOString().slice(0, 10)).toBe('2028-02-29')
-    expect(next.ordinal).toBe(5)
+    expect(next!.date.toISOString().slice(0, 10)).toBe('2028-02-29')
+    expect(next!.ordinal).toBe(5)
   })
 
   it('honours a multi-interval config (every 3 months)', () => {
@@ -246,7 +242,33 @@ describe('firstRecurrenceAfterToday', () => {
       '2026-01-15',
       new Date('2026-07-23T00:00:00.000Z'),
     )
-    expect(next.date.toISOString().slice(0, 10)).toBe('2026-10-15')
+    expect(next!.date.toISOString().slice(0, 10)).toBe('2026-10-15')
+  })
+
+  it('returns null when a DATE end precedes the next candidate after today', () => {
+    const next = firstRecurrenceAfterToday(
+      {
+        frequency: 'MONTHLY',
+        interval: 1,
+        end: {
+          type: 'DATE',
+          endDate: new Date('2026-07-01T00:00:00.000Z'),
+        },
+      },
+      '2026-01-01',
+      new Date('2026-07-15T00:00:00.000Z'),
+    )
+    expect(next).toBeNull()
+  })
+
+  it('returns null when a COUNT end is exhausted', () => {
+    const next = firstRecurrenceAfterToday(
+      { frequency: 'MONTHLY', interval: 1, end: { type: 'COUNT', count: 3 } },
+      '2026-01-01',
+      new Date('2026-02-15T00:00:00.000Z'),
+      3,
+    )
+    expect(next).toBeNull()
   })
 })
 
@@ -260,10 +282,33 @@ describe('planLegacyRecurringImport month-end', () => {
     ]
     const plan = planLegacyRecurringImport(expenses, today)
     expect(plan.series).toHaveLength(1)
-    expect(plan.series[0]!.nextOccurrenceDate.toISOString().slice(0, 10)).toBe(
+    expect(plan.series[0]!.nextOccurrenceDate!.toISOString().slice(0, 10)).toBe(
       '2026-07-31',
     )
     expect(plan.series[0]!.nextOccurrenceOrdinal).toBe(3)
+  })
+
+  it('preserves null nextOccurrenceDate when recurrence end is exhausted', () => {
+    const today = new Date('2026-07-23T12:00:00.000Z')
+    const expenses = [
+      expense({
+        title: 'Limited Gym',
+        expenseDate: '2026-01-01',
+        recurrence: {
+          frequency: 'MONTHLY',
+          interval: 1,
+          end: {
+            type: 'DATE',
+            endDate: new Date('2026-05-01T00:00:00.000Z'),
+          },
+        },
+      }),
+    ]
+    const plan = planLegacyRecurringImport(expenses, today)
+    expect(plan.series).toHaveLength(1)
+    expect(plan.series[0]!.nextOccurrenceDate).toBeNull()
+    expect(plan.series[0]!.nextOccurrenceOrdinal).toBeNull()
+    expect(summarizeLegacyRecurringImport(expenses)).toHaveLength(0)
   })
 })
 

--- a/packages/domain/src/import/recurrence-collapse.test.ts
+++ b/packages/domain/src/import/recurrence-collapse.test.ts
@@ -110,7 +110,15 @@ describe('planLegacyRecurringImport', () => {
       { expenseIndex: 2, sequence: 3, isSeriesAnchor: true },
     ])
     expect(summarizeLegacyRecurringImport(expenses)).toEqual([
-      { title: 'Spotify Monthly', recurrenceRule: 'MONTHLY' },
+      {
+        title: 'Spotify Monthly',
+        recurrenceRule: 'MONTHLY',
+        config: {
+          frequency: 'MONTHLY',
+          interval: 1,
+          end: { type: 'INDEFINITE' },
+        },
+      },
     ])
   })
 
@@ -150,8 +158,24 @@ describe('planLegacyRecurringImport', () => {
     const plan = planLegacyRecurringImport(expenses, today)
     expect(plan.series).toHaveLength(2)
     expect(summarizeLegacyRecurringImport(expenses)).toEqual([
-      { title: 'Rent', recurrenceRule: 'MONTHLY' },
-      { title: 'Rent', recurrenceRule: 'MONTHLY' },
+      {
+        title: 'Rent',
+        recurrenceRule: 'MONTHLY',
+        config: {
+          frequency: 'MONTHLY',
+          interval: 1,
+          end: { type: 'INDEFINITE' },
+        },
+      },
+      {
+        title: 'Rent',
+        recurrenceRule: 'MONTHLY',
+        config: {
+          frequency: 'MONTHLY',
+          interval: 1,
+          end: { type: 'INDEFINITE' },
+        },
+      },
     ])
   })
 
@@ -174,7 +198,7 @@ describe('planLegacyRecurringImport', () => {
 describe('firstRecurrenceDateAfterToday', () => {
   it('advances past overdue dates', () => {
     const next = firstRecurrenceDateAfterToday(
-      'MONTHLY',
+      { frequency: 'MONTHLY', interval: 1, end: { type: 'INDEFINITE' } },
       '2026-06-01',
       new Date('2026-07-23T00:00:00.000Z'),
     )
@@ -185,7 +209,7 @@ describe('firstRecurrenceDateAfterToday', () => {
 describe('firstRecurrenceAfterToday', () => {
   it('returns matching ordinal for the advanced date', () => {
     const next = firstRecurrenceAfterToday(
-      'MONTHLY',
+      { frequency: 'MONTHLY', interval: 1, end: { type: 'INDEFINITE' } },
       '2026-06-01',
       new Date('2026-07-23T00:00:00.000Z'),
     )
@@ -196,7 +220,7 @@ describe('firstRecurrenceAfterToday', () => {
   it('keeps month-end anchors on the 31st after overdue skip (not iterative clamp drift)', () => {
     // Iterative Jan31→Feb28→Mar28… would land on Jul 28; anchored math stays Jul 31.
     const next = firstRecurrenceAfterToday(
-      'MONTHLY',
+      { frequency: 'MONTHLY', interval: 1, end: { type: 'INDEFINITE' } },
       '2025-01-31',
       new Date('2026-07-23T00:00:00.000Z'),
     )
@@ -208,12 +232,21 @@ describe('firstRecurrenceAfterToday', () => {
     // After 2024-02-29, non-leap years clamp to Feb 28; ordinal 5 returns to Feb 29.
     // Iterative stepping from Feb 28 would stay on the 28th forever.
     const next = firstRecurrenceAfterToday(
-      'YEARLY',
+      { frequency: 'YEARLY', interval: 1, end: { type: 'INDEFINITE' } },
       '2024-02-29',
       new Date('2027-03-01T00:00:00.000Z'),
     )
     expect(next.date.toISOString().slice(0, 10)).toBe('2028-02-29')
     expect(next.ordinal).toBe(5)
+  })
+
+  it('honours a multi-interval config (every 3 months)', () => {
+    const next = firstRecurrenceAfterToday(
+      { frequency: 'MONTHLY', interval: 3, end: { type: 'INDEFINITE' } },
+      '2026-01-15',
+      new Date('2026-07-23T00:00:00.000Z'),
+    )
+    expect(next.date.toISOString().slice(0, 10)).toBe('2026-10-15')
   })
 })
 

--- a/packages/domain/src/import/recurrence-collapse.ts
+++ b/packages/domain/src/import/recurrence-collapse.ts
@@ -1,7 +1,7 @@
 import { isSettlementCategory } from '../categories'
 import { calculateRecurrenceDate } from '../recurring-expenses'
 import { legacyRuleToRecurrence, type LegacyRecurrenceRule } from './recurrence'
-import type { RecurrenceConfig, RecurrenceFrequency } from './types'
+import type { RecurrenceConfig } from './types'
 
 /** Minimal expense shape used to collapse legacy recurring rows into series. */
 export type LegacyRecurringCollapseExpense = {
@@ -9,12 +9,32 @@ export type LegacyRecurringCollapseExpense = {
   expenseDate: string | Date
   amount: number
   recurrenceRule: LegacyRecurrenceRule
+  /**
+   * Authoritative series cadence when the source supports it (e.g. Cospend's
+   * yearly / multi-interval / dated-end schedules). When absent, the legacy
+   * `recurrenceRule` is lifted into a config via `legacyRuleToRecurrence`.
+   */
+  recurrence?: RecurrenceConfig | null
   splitMode: string
   category: string
   paidBy: Array<{ id: string; shares: number }>
   paidFor: Array<{ id: string; shares: number }>
   originalCurrency?: string | null
   conversionRate?: number | null
+}
+
+/**
+ * Resolve the effective series config for a collapsed expense: the explicit
+ * `recurrence` when present, else the legacy rule lifted into a config.
+ */
+export function effectiveRecurringConfig(
+  expense: Pick<
+    LegacyRecurringCollapseExpense,
+    'recurrenceRule' | 'recurrence'
+  >,
+): RecurrenceConfig | null {
+  if (expense.recurrence) return expense.recurrence
+  return legacyRuleToRecurrence(expense.recurrenceRule)
 }
 
 export type LegacyRecurringMembership = {
@@ -27,7 +47,12 @@ export type LegacyRecurringMembership = {
 export type LegacyRecurringSeriesPlan = {
   seriesKey: string
   title: string
-  recurrenceRule: Exclude<LegacyRecurrenceRule, 'NONE'>
+  /**
+   * Legacy rule of the anchor expense. May be `NONE` when the authoritative
+   * cadence lives in `config` (e.g. Cospend yearly / multi-interval
+   * schedules).
+   */
+  recurrenceRule: LegacyRecurrenceRule
   config: RecurrenceConfig
   /** Index of the latest (anchor) expense in the input array. */
   anchorIndex: number
@@ -47,7 +72,14 @@ export type LegacyRecurringImportPlan = {
 
 export type LegacyRecurringSummaryItem = {
   title: string
-  recurrenceRule: Exclude<LegacyRecurrenceRule, 'NONE'>
+  /**
+   * Legacy rule for the anchor expense. May be `NONE` when the authoritative
+   * cadence lives in `config` (e.g. Cospend yearly / multi-interval
+   * schedules).
+   */
+  recurrenceRule: LegacyRecurrenceRule
+  /** Authoritative cadence (frequency + interval + end) for the series. */
+  config: RecurrenceConfig
 }
 
 function toUtcDay(value: string | Date): Date {
@@ -73,7 +105,14 @@ function participantFingerprint(
 export function fingerprintLegacyRecurringExpense(
   expense: LegacyRecurringCollapseExpense,
 ): string | null {
-  if (expense.recurrenceRule === 'NONE') return null
+  const config = effectiveRecurringConfig(expense)
+  if (!config) return null
+  const endKey =
+    config.end.type === 'DATE'
+      ? `D:${config.end.endDate.toISOString()}`
+      : config.end.type === 'COUNT'
+        ? `C:${config.end.count}`
+        : 'I'
   const currency = expense.originalCurrency ?? ''
   const rate =
     expense.conversionRate === null || expense.conversionRate === undefined
@@ -81,7 +120,9 @@ export function fingerprintLegacyRecurringExpense(
       : String(expense.conversionRate)
   return [
     expense.title,
-    expense.recurrenceRule,
+    config.frequency,
+    String(config.interval),
+    endKey,
     String(expense.amount),
     expense.splitMode,
     isSettlementCategory(expense.category) ? '1' : '0',
@@ -99,16 +140,12 @@ export function fingerprintLegacyRecurringExpense(
  * both the date and the 1-based anchored ordinal for that date.
  */
 export function firstRecurrenceAfterToday(
-  rule: RecurrenceFrequency,
+  config: RecurrenceConfig,
   latestExpenseDate: string | Date,
   today: Date = new Date(),
 ): { date: Date; ordinal: number } {
   const todayDay = toUtcDay(today)
   const anchor = toUtcDay(latestExpenseDate)
-  const config = legacyRuleToRecurrence(rule)
-  if (!config) {
-    throw new RangeError('recurrence rule must not be NONE')
-  }
   let ordinal = 2
   let next = calculateRecurrenceDate(
     anchor,
@@ -133,11 +170,11 @@ export function firstRecurrenceAfterToday(
  * strictly after `today` (UTC calendar day). Skips import catch-up backlogs.
  */
 export function firstRecurrenceDateAfterToday(
-  rule: RecurrenceFrequency,
+  config: RecurrenceConfig,
   latestExpenseDate: string | Date,
   today: Date = new Date(),
 ): Date {
-  return firstRecurrenceAfterToday(rule, latestExpenseDate, today).date
+  return firstRecurrenceAfterToday(config, latestExpenseDate, today).date
 }
 
 /**
@@ -169,9 +206,7 @@ export function planLegacyRecurringImport(
     })
     const anchorIndex = ordered[ordered.length - 1]!
     const anchor = expenses[anchorIndex]!
-    const recurrenceRule = anchor.recurrenceRule
-    if (recurrenceRule === 'NONE') continue
-    const config = legacyRuleToRecurrence(recurrenceRule)
+    const config = effectiveRecurringConfig(anchor)
     if (!config) continue
 
     ordered.forEach((expenseIndex, offset) => {
@@ -183,15 +218,11 @@ export function planLegacyRecurringImport(
       })
     })
 
-    const next = firstRecurrenceAfterToday(
-      recurrenceRule,
-      anchor.expenseDate,
-      today,
-    )
+    const next = firstRecurrenceAfterToday(config, anchor.expenseDate, today)
     series.push({
       seriesKey,
       title: anchor.title,
-      recurrenceRule,
+      recurrenceRule: anchor.recurrenceRule,
       config,
       anchorIndex,
       occurrenceCount: ordered.length,
@@ -216,6 +247,7 @@ export function summarizeLegacyRecurringImport(
   return planLegacyRecurringImport(expenses).series.map((plan) => ({
     title: plan.title,
     recurrenceRule: plan.recurrenceRule,
+    config: plan.config,
   }))
 }
 
@@ -224,6 +256,7 @@ export function collapseExpenseFromNormalized(expense: {
   expenseDate: string
   amount: number
   recurrenceRule: LegacyRecurrenceRule
+  recurrence?: RecurrenceConfig | null
   splitMode: string
   category: string
   paidBySourceId?: string
@@ -243,6 +276,7 @@ export function collapseExpenseFromNormalized(expense: {
     expenseDate: expense.expenseDate,
     amount: expense.amount,
     recurrenceRule: expense.recurrenceRule,
+    recurrence: expense.recurrence ?? null,
     splitMode: expense.splitMode,
     category: expense.category,
     paidBy,
@@ -260,6 +294,7 @@ export function collapseExpenseFromApi(expense: {
   expenseDate: string | Date
   amount: number
   recurrenceRule?: LegacyRecurrenceRule | null
+  recurrence?: RecurrenceConfig | null
   splitMode: string
   category: string
   paidByList: Array<{ participant: string; shares: number }>
@@ -285,6 +320,7 @@ export function collapseExpenseFromApi(expense: {
     expenseDate: expense.expenseDate,
     amount: expense.amount,
     recurrenceRule: expense.recurrenceRule ?? 'NONE',
+    recurrence: expense.recurrence ?? null,
     splitMode: expense.splitMode,
     category: expense.category,
     paidBy: expense.paidByList.map((row) => ({

--- a/packages/domain/src/import/recurrence-collapse.ts
+++ b/packages/domain/src/import/recurrence-collapse.ts
@@ -57,12 +57,12 @@ export type LegacyRecurringSeriesPlan = {
   /** Index of the latest (anchor) expense in the input array. */
   anchorIndex: number
   occurrenceCount: number
-  nextOccurrenceDate: Date
+  nextOccurrenceDate: Date | null
   /**
    * 1-based anchored ordinal for `nextOccurrenceDate` (may be > 2 after
-   * skipping overdue).
+   * skipping overdue). `null` when the schedule end condition is exhausted.
    */
-  nextOccurrenceOrdinal: number
+  nextOccurrenceOrdinal: number | null
 }
 
 export type LegacyRecurringImportPlan = {
@@ -137,15 +137,31 @@ export function fingerprintLegacyRecurringExpense(
  * Advance from the day after the latest occurrence until the first date
  * strictly after `today` (UTC calendar day). Uses anchored occurrence math
  * (same as materialization), not iterative next-from-previous stepping. Returns
- * both the date and the 1-based anchored ordinal for that date.
+ * both the date and the 1-based anchored ordinal for that date, or `null` if
+ * the series end condition (DATE or COUNT) is exhausted.
  */
 export function firstRecurrenceAfterToday(
   config: RecurrenceConfig,
   latestExpenseDate: string | Date,
   today: Date = new Date(),
-): { date: Date; ordinal: number } {
+  latestOccurrenceNumber = 1,
+): { date: Date; ordinal: number } | null {
   const todayDay = toUtcDay(today)
   const anchor = toUtcDay(latestExpenseDate)
+
+  if (
+    config.end.type === 'DATE' &&
+    anchor.getTime() >= toUtcDay(config.end.endDate).getTime()
+  ) {
+    return null
+  }
+  if (
+    config.end.type === 'COUNT' &&
+    latestOccurrenceNumber >= config.end.count
+  ) {
+    return null
+  }
+
   let ordinal = 2
   let next = calculateRecurrenceDate(
     anchor,
@@ -154,6 +170,18 @@ export function firstRecurrenceAfterToday(
     ordinal,
   )
   while (next.getTime() <= todayDay.getTime()) {
+    if (
+      config.end.type === 'DATE' &&
+      next.getTime() > toUtcDay(config.end.endDate).getTime()
+    ) {
+      return null
+    }
+    if (
+      config.end.type === 'COUNT' &&
+      latestOccurrenceNumber + ordinal - 1 > config.end.count
+    ) {
+      return null
+    }
     ordinal += 1
     next = calculateRecurrenceDate(
       anchor,
@@ -162,19 +190,36 @@ export function firstRecurrenceAfterToday(
       ordinal,
     )
   }
+
+  if (
+    config.end.type === 'DATE' &&
+    next.getTime() > toUtcDay(config.end.endDate).getTime()
+  ) {
+    return null
+  }
+  if (
+    config.end.type === 'COUNT' &&
+    latestOccurrenceNumber + ordinal - 1 > config.end.count
+  ) {
+    return null
+  }
+
   return { date: next, ordinal }
 }
 
 /**
  * Advance from the day after the latest occurrence until the first date
  * strictly after `today` (UTC calendar day). Skips import catch-up backlogs.
+ * Returns `null` if the series end condition is exhausted.
  */
 export function firstRecurrenceDateAfterToday(
   config: RecurrenceConfig,
   latestExpenseDate: string | Date,
   today: Date = new Date(),
-): Date {
-  return firstRecurrenceAfterToday(config, latestExpenseDate, today).date
+): Date | null {
+  return (
+    firstRecurrenceAfterToday(config, latestExpenseDate, today)?.date ?? null
+  )
 }
 
 /**
@@ -218,7 +263,12 @@ export function planLegacyRecurringImport(
       })
     })
 
-    const next = firstRecurrenceAfterToday(config, anchor.expenseDate, today)
+    const next = firstRecurrenceAfterToday(
+      config,
+      anchor.expenseDate,
+      today,
+      ordered.length,
+    )
     series.push({
       seriesKey,
       title: anchor.title,
@@ -226,8 +276,8 @@ export function planLegacyRecurringImport(
       config,
       anchorIndex,
       occurrenceCount: ordered.length,
-      nextOccurrenceDate: next.date,
-      nextOccurrenceOrdinal: next.ordinal,
+      nextOccurrenceDate: next ? next.date : null,
+      nextOccurrenceOrdinal: next ? next.ordinal : null,
     })
   }
 
@@ -244,11 +294,13 @@ export function planLegacyRecurringImport(
 export function summarizeLegacyRecurringImport(
   expenses: LegacyRecurringCollapseExpense[],
 ): LegacyRecurringSummaryItem[] {
-  return planLegacyRecurringImport(expenses).series.map((plan) => ({
-    title: plan.title,
-    recurrenceRule: plan.recurrenceRule,
-    config: plan.config,
-  }))
+  return planLegacyRecurringImport(expenses)
+    .series.filter((plan) => plan.nextOccurrenceDate !== null)
+    .map((plan) => ({
+      title: plan.title,
+      recurrenceRule: plan.recurrenceRule,
+      config: plan.config,
+    }))
 }
 
 export function collapseExpenseFromNormalized(expense: {

--- a/packages/domain/src/import/types.ts
+++ b/packages/domain/src/import/types.ts
@@ -56,7 +56,7 @@ export type NormalizedSourceExpense = {
 }
 
 export type NormalizedSource = {
-  provider: 'SPLIIT' | 'SPLITWISE'
+  provider: 'SPLIIT' | 'SPLITWISE' | 'COSPEND'
   /** Null identifies the original unversioned spliit.app export. */
   exportVersion?: 3 | null
   sourceGroupId: string

--- a/scripts/i18n/src/english-identity.ts
+++ b/scripts/i18n/src/english-identity.ts
@@ -13,6 +13,7 @@ const BRAND_TOKENS = new Set([
   'GitHub',
   'Spliit',
   'Splitwise',
+  'Cospend',
   'Maxio',
   'Apple',
   'Google',

--- a/storage/maxio/buckets/spliit-local/.bucket.json
+++ b/storage/maxio/buckets/spliit-local/.bucket.json
@@ -1,17 +1,5 @@
 {
   "name": "spliit-local",
-  "created_at": "2026-07-03T13:12:20.559Z",
-  "region": "us-east-1",
-  "public_read": true,
-  "cors_rules": [
-    {
-      "allowed_origins": ["http://localhost:3000"],
-      "allowed_methods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
-      "allowed_headers": ["*"],
-      "expose_headers": ["ETag", "x-amz-version-id", "x-amz-request-id"],
-      "max_age_seconds": 3600
-    }
-  ],
-  "encryption_config": null,
-  "public_list": false
+  "created_at": "2026-09-06T21:51:37.080Z",
+  "region": "us-east-1"
 }

--- a/storage/maxio/buckets/spliit-local/.bucket.json
+++ b/storage/maxio/buckets/spliit-local/.bucket.json
@@ -1,5 +1,17 @@
 {
   "name": "spliit-local",
-  "created_at": "2026-09-06T21:51:37.080Z",
-  "region": "us-east-1"
+  "created_at": "2026-07-03T13:12:20.559Z",
+  "region": "us-east-1",
+  "public_read": true,
+  "cors_rules": [
+    {
+      "allowed_origins": ["http://localhost:3000"],
+      "allowed_methods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+      "allowed_headers": ["*"],
+      "expose_headers": ["ETag", "x-amz-version-id", "x-amz-request-id"],
+      "max_age_seconds": 3600
+    }
+  ],
+  "encryption_config": null,
+  "public_list": false
 }


### PR DESCRIPTION
## Summary

Fixes #110 

## Changes

Add a client-side Cospend CSV importer that feeds the existing group
   import pipeline (mirrors the Splitwise CSV flow), so Cospend projects
   can be imported into Spliit groups.

   - domain: new tryParseCospendCsv() parses the sectioned Cospend export
     (members, bills, categories, payment modes, optional currencies) into a
     NormalizedSource with provider 'COSPEND'; weight-proportional splits,
     best-effort category mapping, deleted-bill skipping, EUR default currency
   - domain: make the recurring-collapse pipeline config-aware via
     effectiveRecurringConfig() so yearly / multi-interval (repeatfreq) /
     dated-end (repeatuntil) schedules survive the import; previously only the
     legacy DAILY/WEEKLY/MONTHLY rule was honored and the full RecurrenceConfig
     was stripped, silently dropping those recurrences
   - api: importExpenseSchema no longer strips `recurrence` (validated by
     expenseApiSchema); add COSPEND to the provider enum
   - web: new Cospend tab in the import wizard, config-based recurrence labels
     in the confirm step (yearly / every N / dated-end), i18n strings
   - tests: cospend-csv parser tests, config-based recurrence-collapse tests,
     Cospend filename + source-step tab coverage

## Verification

- [x] `bun run check`
- [x] `bun run test`
- [x] I added or updated tests where appropriate.

## AI-assisted development disclosure

<!-- AI agent contributions are welcome. If AI was used, choose one of the two
     options below and include the requested material. Redact secrets and
     private data from prompts. -->

- [ ] No AI assistance was used.
- [x] AI was used, and I included the initial prompt plus all materially
      relevant follow-up prompts below (with notes on important changes or
      decisions).

### Prompt history

Issue #110 "Import from Cospend" is now fully implemented and integrated into the existing Spliit import pipeline.

 What was built

 A client-side Cospend CSV importer (mirroring the Splitwise CSV flow) that imports Cospend projects into Spliit
 groups, maps bills to expenses, and maps recurring bills to recurring series.

 ### Domain (packages/domain/src/import/)

 - cospend-csv.ts (new) — tryParseCospendCsv() parses Cospend's sectioned CSV (members / bills / categories / payment
   modes / optional currencies) into a NormalizedSource with provider: 'COSPEND'. Handles weight-proportional splits
   (scaled integer weights + rational remainder distribution), recurrence mapping, category fallback, deleted-bill
   skipping, and base-currency detection (defaults to EUR).
 - cospend-categories.ts (new) — best-effort keyword mapping of Cospend category names → Spliit CategoryId.
 - recurrence-collapse.ts — made the collapse logic config-aware: effectiveRecurringConfig() prefers an explicit
   RecurrenceConfig over the legacy rule, so Cospend's yearly / multi-interval (repeatfreq) / dated-end (repeatuntil)
   schedules survive the import. Fingerprinting, planning, and summary now key off the full config.
 - filename.ts — humanizes Cospend <slug>_<date> filenames into a default group name.
 - types.ts / index.ts — registered COSPEND and exported the new modules.

 ### API

 - import.procedure.ts — importExpenseSchema no longer strips recurrence (now validated by expenseApiSchema), so the
   authoritative cadence reaches the series planner.
 - outputs/imports.ts — added COSPEND to the provider enum.

 ### Web

 - source-providers.ts / source-step.tsx — new Cospend tab + description card + drop-file labels.
 - confirm-step.tsx — recurrence labels now render from the config (yearly, "Every N months", dated-end) instead of
   only DAILY|WEEKLY|MONTHLY.
 - router/schemas.ts — added cospend to the import search enum.
 - en-US.json — i18n strings for the tab, descriptions, and recurrence labels.

 Verification

 - Domain typecheck ✅ clean · import tests ✅ 312 passed (incl. 16 new Cospend parser tests)
 - API / Web typecheck ✅ only the pre-existing import-cloud.ts Prisma error (confirmed present on a clean tree)
 - Web import tests ✅ 103 passed
 - Real sample CSVs parse correctly: family-zu-besuch → 25 expenses, osterreich-2026 → 12 expenses, correct even/odd
   splits, EUR currency, humanized group names.

 Pre-existing failures unrelated to this work (verified on a clean tree): shares.test.ts (locale),
 expense-preview-modal.test.ts (share-ratio labels), and the import-cloud.ts type error.

 The live Cospend instance was only ever probed read-only, and those temp probe scripts have been cleaned up.

## Checklist

- [x] The implementation is complete and I have reviewed all AI-generated code.
- [x] Documentation is updated when needed.
- [x] Schema changes include the schema, migration, and generated client.
- [ ] This PR contains one logical change.
- [x] Related issue: `Closes #110 `


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing Cospend project CSV exports, including members, expenses, categories, comments, currencies, splits, and recurring schedules.
  * Added Cospend as an import source with category mapping and group-name detection.
  * Added custom recurrence intervals, yearly schedules, and recurrence end dates.
  * Import confirmations now show clearer recurrence details.
* **Bug Fixes**
  * Detailed recurrence settings now take precedence over legacy rules.
  * Completed recurring series are no longer scheduled for additional occurrences.
* **Documentation**
  * Added guidance that receipt images are not imported from Cospend exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->